### PR TITLE
Fix linting issues and re-org Kube Agent

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,13 @@
+linters:
+  disable-all: true
+  enable:
+    - unconvert   # Remove unnecessary type conversions
+    - unused      # Checks Go code for unused constants, variables, functions and types
+    - ineffassign # Detects when assignments to existing variables are not used
+    - misspell    # Finds commonly misspelled English words in comments
+    - gofmt       # Gofmt checks whether code was gofmt-ed
+    - revive      # Revive is a replacement for golint, a coding style checker
+    - errcheck    # errcheck is a program for checking for unchecked errors in go programs.
+    - staticcheck # staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - govet       # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - bodyclose   # checks whether HTTP response body is closed successfully

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ vet:
 	go vet
 
 lint:
-	golangci-lint run --enable-all
+	golangci-lint run

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -17,31 +17,58 @@ type Agent interface {
 	ListenForConfigChanges(ctx context.Context) error
 }
 
-// Config stores general configuration for all agent types
-type Config struct {
-	ApiKey                    string
+// BaseConfig stores general configuration for all agent types
+type BaseConfig struct {
+	APIKey                    string
 	Target                    string
-	ConfigCheckInterval       string
-	ApiURLForConfigCheck      string
-	HostTags                  string
-	DockerEndpoint            string
 	EnableSyntheticMonitoring bool
-	Logfile                   string
-	LogfileSize               int
+	ConfigCheckInterval       string
+	DockerEndpoint            string
+	APIURLForConfigCheck      string
 }
 
-// String() implements stringer interface for Config
-func (c Config) String() string {
+// String() implements stringer interface for BaseConfig
+func (c BaseConfig) String() string {
 	var s string
-	s += fmt.Sprintf("api-key: %s, ", c.ApiKey)
+	s += fmt.Sprintf("api-key: %s, ", c.APIKey)
 	s += fmt.Sprintf("target: %s, ", c.Target)
-	s += fmt.Sprintf("config-check-interval: %s, ", c.ConfigCheckInterval)
-	s += fmt.Sprintf("api-url-for-config-check: %s, ", c.ApiURLForConfigCheck)
-	s += fmt.Sprintf("host-tags: %s, ", c.HostTags)
-	s += fmt.Sprintf("docker-endpoint: %s, ", c.DockerEndpoint)
 	s += fmt.Sprintf("enable-synthetic-monitoring: %t, ", c.EnableSyntheticMonitoring)
-	s += fmt.Sprintf("logfile: %s, ", c.Logfile)
-	s += fmt.Sprintf("logfile-size: %d", c.LogfileSize)
+	s += fmt.Sprintf("config-check-interval: %s, ", c.ConfigCheckInterval)
+	s += fmt.Sprintf("docker-endpoint: %s, ", c.DockerEndpoint)
+	s += fmt.Sprintf("api-url-for-config-check: %s, ", c.APIURLForConfigCheck)
+
+	return s
+}
+
+// HostConfig stores configuration for all the host agent
+type HostConfig struct {
+	BaseConfig
+
+	HostTags    string
+	Logfile     string
+	LogfileSize int
+}
+
+// String() implements stringer interface for HostConfig
+func (h HostConfig) String() string {
+	s := h.BaseConfig.String()
+	s += fmt.Sprintf("host-tags: %s, ", h.HostTags)
+	s += fmt.Sprintf("logfile: %s, ", h.Logfile)
+	s += fmt.Sprintf("logfile-size: %d", h.LogfileSize)
+	return s
+}
+
+// KubeConfig stores configuration for all the host agent
+type KubeConfig struct {
+	BaseConfig
+	InsightRefreshDuration string
+}
+
+// String() implements stringer interface for KubeConfig
+func (k KubeConfig) String() string {
+	s := k.BaseConfig.String()
+	s += fmt.Sprintf("insight-refresh-duration: %s",
+		k.InsightRefreshDuration)
 	return s
 }
 
@@ -53,7 +80,7 @@ func isSocket(path string) bool {
 	return fileInfo.Mode().Type() == fs.ModeSocket
 }
 
-var isSocketFn func(path string) bool = isSocket
+var isSocketFn = isSocket
 
 func getHostname() string {
 	hostname, err := os.Hostname()

--- a/pkg/agent/hostagent_linux.go
+++ b/pkg/agent/hostagent_linux.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetFactories get otel factories for HostAgent
-func (c *HostAgent) GetFactories(ctx context.Context) (otelcol.Factories, error) {
+func (c *HostAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 	var err error
 	factories := otelcol.Factories{}
 	factories.Extensions, err = extension.MakeFactoryMap(

--- a/pkg/agent/hostagent_test.go
+++ b/pkg/agent/hostagent_test.go
@@ -27,7 +27,7 @@ func TestUpdatepgdbConfig(t *testing.T) {
 		Path: "db-config_test.yaml",
 	}
 
-	agent := NewHostAgent(Config{}, WithHostAgentLogger(zap.NewNop()))
+	agent := NewHostAgent(HostConfig{}, WithHostAgentLogger(zap.NewNop()))
 	// Call the updatepgdbConfig function
 	updatedConfig, err := agent.updatepgdbConfig(initialConfig, pgdbConfig)
 	assert.NoError(t, err)
@@ -62,7 +62,7 @@ func TestUpdateMongodbConfig(t *testing.T) {
 		Path: "db-config_test.yaml",
 	}
 
-	agent := NewHostAgent(Config{}, WithHostAgentLogger(zap.NewNop()))
+	agent := NewHostAgent(HostConfig{}, WithHostAgentLogger(zap.NewNop()))
 
 	updatedConfig, err := agent.updateMongodbConfig(initialConfig, mongodbConfig)
 	assert.NoError(t, err)
@@ -97,7 +97,7 @@ func TestUpdateMysqlConfig(t *testing.T) {
 		Path: "db-config_test.yaml",
 	}
 
-	cfg := Config{}
+	cfg := HostConfig{}
 	agent := NewHostAgent(cfg, WithHostAgentLogger(zap.NewNop()))
 	// Call the updateMysqlConfig function
 	updatedConfig, err := agent.updateMysqlConfig(initialConfig, mysqlConfig)
@@ -117,9 +117,8 @@ func TestUpdateMysqlConfig(t *testing.T) {
 }
 
 func TestListenForConfigChanges(t *testing.T) {
-	cfg := Config{
-		ConfigCheckInterval: "1s",
-	}
+	cfg := HostConfig{}
+	cfg.ConfigCheckInterval = "1s"
 	agent := NewHostAgent(cfg, WithHostAgentLogger(zap.NewNop()))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -145,7 +144,7 @@ func TestListenForConfigChanges(t *testing.T) {
 }
 
 func TestHostAgentGetFactories(t *testing.T) {
-	agent := NewHostAgent(Config{}, WithHostAgentLogger(zap.NewNop()))
+	agent := NewHostAgent(HostConfig{}, WithHostAgentLogger(zap.NewNop()))
 
 	factories, err := agent.GetFactories(context.Background())
 	assert.NoError(t, err)
@@ -208,7 +207,7 @@ func TestHostAgentHasValidTags(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		agent := NewHostAgent(Config{
+		agent := NewHostAgent(HostConfig{
 			HostTags: tc.tags,
 		})
 

--- a/pkg/agent/kubeagent.go
+++ b/pkg/agent/kubeagent.go
@@ -33,61 +33,12 @@ import (
 
 // KubeAgent implements Agent interface for Kubernetes
 type KubeAgent struct {
-	apiKey string
-	target string
-
-	enableSytheticMonitoring bool
-	configCheckInterval      string
-
-	apiURLForConfigCheck string
-
-	logger         *zap.Logger
-	dockerEndpoint string
+	KubeConfig
+	logger *zap.Logger
 }
 
 // KubeOptions takes in various options for KubeAgent
 type KubeOptions func(h *KubeAgent)
-
-// WithKubeAgentApiKey sets api key for interacting with
-// the Middleware backend
-func WithKubeAgentApiKey(key string) KubeOptions {
-	return func(h *KubeAgent) {
-		h.apiKey = key
-	}
-}
-
-// WithKubeAgentTarget sets target URL for sending insights
-// to the Middlware backend.
-func WithKubeAgentTarget(t string) KubeOptions {
-	return func(h *KubeAgent) {
-		h.target = t
-	}
-}
-
-// WithKubeAgentEnableSyntheticMonitoring enables synthetic
-// monitoring to be performed from the agent.
-// Note: This is currently not supported in KubeAgent
-func WithKubeAgentEnableSyntheticMonitoring(e bool) KubeOptions {
-	return func(h *KubeAgent) {
-		h.enableSytheticMonitoring = e
-	}
-}
-
-// WithKubeAgentConfigCheckInterval sets the duration for checking with
-// the Middleware backend for configuration update.
-func WithKubeAgentConfigCheckInterval(c string) KubeOptions {
-	return func(h *KubeAgent) {
-		h.configCheckInterval = c
-	}
-}
-
-// WithKubeAgentApiURLForConfigCheck sets the URL for the periodic
-// configuration check.
-func WithKubeAgentApiURLForConfigCheck(u string) KubeOptions {
-	return func(h *KubeAgent) {
-		h.apiURLForConfigCheck = u
-	}
-}
 
 // WithKubeAgentLogger sets the logger to be used with agent logs
 func WithKubeAgentLogger(logger *zap.Logger) KubeOptions {
@@ -96,32 +47,25 @@ func WithKubeAgentLogger(logger *zap.Logger) KubeOptions {
 	}
 }
 
-// WithKubeAgentDockerEndpoint sets the endpoint for docker so that
-// the agent can figure out if it needs to send docker logs & metrics.
-func WithKubeAgentDockerEndpoint(endpoint string) KubeOptions {
-	return func(h *KubeAgent) {
-		h.dockerEndpoint = endpoint
-	}
-}
-
 // NewKubeAgent returns new agent for Kubernetes with given options.
-func NewKubeAgent(opts ...KubeOptions) *KubeAgent {
-	var cfg KubeAgent
+func NewKubeAgent(cfg KubeConfig, opts ...KubeOptions) *KubeAgent {
+	var agent KubeAgent
+	agent.KubeConfig = cfg
 	for _, apply := range opts {
-		apply(&cfg)
+		apply(&agent)
 	}
 
-	if cfg.logger == nil {
-		cfg.logger, _ = zap.NewProduction()
+	if agent.logger == nil {
+		agent.logger, _ = zap.NewProduction()
 	}
 
-	return &cfg
+	return &agent
 }
 
 // GetUpdatedYAMLPath gets the correct otel configuration file.
 func (k *KubeAgent) GetUpdatedYAMLPath() (string, error) {
 	yamlPath := "/app/otel-config.yaml"
-	dockerSocketPath := strings.Split(k.dockerEndpoint, "//")
+	dockerSocketPath := strings.Split(k.DockerEndpoint, "//")
 
 	if len(dockerSocketPath) != 2 || !isSocketFn(dockerSocketPath[1]) {
 		yamlPath = "/app/otel-config-nodocker.yaml"
@@ -131,7 +75,7 @@ func (k *KubeAgent) GetUpdatedYAMLPath() (string, error) {
 }
 
 // GetFactories get otel factories for KubeAgent
-func (k *KubeAgent) GetFactories(ctx context.Context) (otelcol.Factories, error) {
+func (k *KubeAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 	var err error
 	factories := otelcol.Factories{}
 	factories.Extensions, err = extension.MakeFactoryMap(

--- a/pkg/agent/kubeagent_test.go
+++ b/pkg/agent/kubeagent_test.go
@@ -16,9 +16,10 @@ func setIsSocketMock(b bool) {
 }
 
 func TestGetUpdatedYAMLPath(t *testing.T) {
-	agent := NewKubeAgent(
-		WithKubeAgentLogger(zap.NewNop()),
-		WithKubeAgentDockerEndpoint("unix:///var/run/docker.sock"))
+	var cfg KubeConfig
+	cfg.DockerEndpoint = "unix:///var/run/docker.sock"
+	agent := NewKubeAgent(cfg,
+		WithKubeAgentLogger(zap.NewNop()))
 
 	// Test when docker socket is found
 	yamlPath, err := agent.GetUpdatedYAMLPath()
@@ -39,7 +40,7 @@ func TestGetUpdatedYAMLPath(t *testing.T) {
 }
 
 func TestKubeAgentGetFactories(t *testing.T) {
-	agent := NewKubeAgent()
+	agent := NewKubeAgent(KubeConfig{})
 
 	factories, err := agent.GetFactories(context.Background())
 	assert.NoError(t, err)

--- a/pkg/mwinsight/k8sinsight_test.go
+++ b/pkg/mwinsight/k8sinsight_test.go
@@ -3,7 +3,7 @@ package mwinsight
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -110,7 +110,7 @@ func TestAnalyze(t *testing.T) {
 			insight := NewK8sInsight(
 				WithK8sInsightK8sClient(k8sClient),
 				WithK8sInsightBackend(BackendTypeOpenAI),
-				WithK8sInsightApiKey("1234"),
+				WithK8sInsightAPIKey("1234"),
 				WithK8sInsightTarget("https://test.middleware.io"),
 				WithK8sInsightK8sNameSpace(test.namespace),
 			)
@@ -160,7 +160,7 @@ func TestSend(t *testing.T) {
 				assert.Equal(t, "POST", r.Method)
 
 				// Read the request body
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 
 				// Assert the request body contains the expected data
@@ -185,7 +185,7 @@ func TestSend(t *testing.T) {
 				assert.Equal(t, "POST", r.Method)
 
 				// Read the request body
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 
 				// Assert the request body contains the expected data
@@ -211,7 +211,7 @@ func TestSend(t *testing.T) {
 			}
 			insight := NewK8sInsight(
 				WithK8sInsightBackend(BackendTypeOpenAI),
-				WithK8sInsightApiKey(test.apiKey),
+				WithK8sInsightAPIKey(test.apiKey),
 				WithK8sInsightTarget(serverURL),
 				WithK8sInsightLogger(logger),
 			)


### PR DESCRIPTION
Added `golangci-lint` support to lint the code

Reorganized Kube Agent similar to the Host Agent.