### PR TITLE
updating apt + rpm workflow with CGO_ENABLED=0 to create static binaries

### DIFF
--- a/.github/workflows/host-agent-deb-apt.yaml
+++ b/.github/workflows/host-agent-deb-apt.yaml
@@ -93,16 +93,11 @@ jobs:
       with:
         go-version: 1.20.0
 
+    # Building with CGO_ENABLED=0 so that we can build static binary which is not dependent on any external libraries
+    # Building with -ldflags="-s -w" to reduce the size of binary
     - name: Go Build
       run: |
-        if [ ${{ matrix.arch }} == "x64" ]; then
-          go build -o $BINARY_SOURCE cmd/host-agent/main.go
-        elif [ ${{ matrix.arch }} == "ARM" ]; then
-          GOOS=linux GOARCH=$ARCH go build -a -o $BINARY_SOURCE cmd/host-agent/main.go
-        else
-          echo "Unsupported architecture"
-          exit 1
-        fi
+        CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH go build -ldflags="-s -w" -v -a -o $BINARY_SOURCE cmd/host-agent/main.go
         
 
     - name: Copying Code Binary into target location

--- a/.github/workflows/host-agent-rpm.yaml
+++ b/.github/workflows/host-agent-rpm.yaml
@@ -148,16 +148,11 @@ jobs:
       with:
         go-version: 1.20.0
 
+    # Building with CGO_ENABLED=0 so that we can build static binary which is not dependent on any external libraries
+    # Building with -ldflags="-s -w" to reduce the size of binary
     - name: Go Build
       run: |
-        if [ ${{ matrix.arch }} == "x64" ]; then
-          go build -v -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
-        elif [ ${{ matrix.arch }} == "ARM" ]; then
-          GOOS=linux GOARCH=$ARCH  go build -ldflags="-s -w" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
-        else
-          echo "Unsupported architecture"
-          exit 1
-        fi
+        CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH  go build -ldflags="-s -w" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
 
     - name: Tar Building
       run: |


### PR DESCRIPTION
Added CGO_ENABLED=0 for static binaries, This is expected to not break with glibc version on host machines