### PR TITLE
adding version info in hostagent

### DIFF
--- a/.github/workflows/host-agent-deb-apt.yaml
+++ b/.github/workflows/host-agent-deb-apt.yaml
@@ -98,9 +98,9 @@ jobs:
     - name: Go Build
       run: |
         if [ ${{ matrix.arch }} == "x64" ]; then
-          CGO_ENABLED=0 go build -ldflags="-s -w" -v -a -o $BINARY_SOURCE cmd/host-agent/main.go
+          CGO_ENABLED=0 go build -ldflags="-s -w -X main.agentVersion=${RELEASE_VERSION}" -v -a -o $BINARY_SOURCE cmd/host-agent/main.go
         elif [ ${{ matrix.arch }} == "ARM" ]; then
-          CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH go build -ldflags="-s -w" -v -a -o $BINARY_SOURCE cmd/host-agent/main.go
+          CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH go build -ldflags="-s -w -X main.agentVersion=${RELEASE_VERSION}" -v -a -o $BINARY_SOURCE cmd/host-agent/main.go
         fi
 
     - name: Copying Code Binary into target location

--- a/.github/workflows/host-agent-docker.yaml
+++ b/.github/workflows/host-agent-docker.yaml
@@ -58,5 +58,6 @@ jobs:
           file: DockerfileLinux
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: AGENT_VERSION=${{  github.event.inputs.tag || steps.meta.outputs.tags }}
           tags: | 
             ghcr.io/middleware-labs/mw-host-agent:${{  github.event.inputs.tag || steps.meta.outputs.tags }}

--- a/.github/workflows/host-agent-rpm.yaml
+++ b/.github/workflows/host-agent-rpm.yaml
@@ -153,9 +153,9 @@ jobs:
     - name: Go Build
       run: |
         if [ ${{ matrix.arch }} == "x64" ]; then
-          CGO_ENABLED=0 go build -ldflags="-s -w" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
+          CGO_ENABLED=0 go build -ldflags="-s -w -X main.agentVersion=${RELEASE_VERSION}" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
         elif [ ${{ matrix.arch }} == "ARM" ]; then
-          CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH  go build -ldflags="-s -w" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
+          CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH  go build -ldflags="-s -w -X main.agentVersion=${RELEASE_VERSION}" -v -a -o ~/rpmbuild/SOURCES/$BINARY_NAME-$RELEASE_VERSION/$BINARY_NAME cmd/host-agent/main.go
         fi
         
     - name: Tar Building

--- a/.github/workflows/kube-agent-docker.yaml
+++ b/.github/workflows/kube-agent-docker.yaml
@@ -50,6 +50,7 @@ jobs:
           file: DockerfileKube
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: AGENT_VERSION=${{  github.event.inputs.tag || steps.meta.outputs.tags }}
           tags: | 
             ghcr.io/middleware-labs/mw-kube-agent:${{  github.event.inputs.tag || steps.meta.outputs.tags }}
             ghcr.io/middleware-labs/agent-kube-go:${{  github.event.inputs.tag || steps.meta.outputs.tags }}

--- a/DockerfileKube
+++ b/DockerfileKube
@@ -5,7 +5,11 @@ RUN update-ca-certificates
 COPY . .
 ENV CGO_ENABLED=0
 RUN go get -d -v ./... && go mod tidy
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /tmp/mw-agent cmd/kube-agent/main.go
+
+ARG AGENT_VERSION
+ENV AGENT_VERSION=$AGENT_VERSION
+
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.agentVersion=${AGENT_VERSION}" -o /tmp/mw-agent cmd/kube-agent/main.go
 
 FROM busybox:glibc as prod
 WORKDIR /app

--- a/DockerfileLinux
+++ b/DockerfileLinux
@@ -5,7 +5,11 @@ RUN update-ca-certificates
 COPY . .
 ENV CGO_ENABLED=0
 RUN go get -d -v ./... && go mod tidy
-RUN CGO_ENABLED=0 go build -o /tmp/mw-agent cmd/host-agent/main.go
+
+ARG AGENT_VERSION
+ENV AGENT_VERSION=$AGENT_VERSION
+
+RUN CGO_ENABLED=0 go build -o -ldflags "-s -w -X main.agentVersion=${AGENT_VERSION}" /tmp/mw-agent cmd/host-agent/main.go
 
 FROM busybox:glibc as prod
 RUN mkdir -p /var/log

--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -2,9 +2,13 @@ FROM golang:1.16-windowsservercore-ltsc2019 as base
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 WORKDIR /app
 COPY . .
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 RUN go get -d -v ./... && go mod tidy
-RUN CGO_ENABLED=1 go build -o /tmp/api-server.exe ./*.go
+
+ARG AGENT_VERSION
+ENV AGENT_VERSION=$AGENT_VERSION
+
+RUN CGO_ENABLED=0 go build -o -ldflags "-s -w -X main.agentVersion=${AGENT_VERSION}" /tmp/api-server.exe ./*.go
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022 as prod
 RUN mkdir -p /var/log

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -27,6 +28,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+var agentVersion = "0.0.1"
 
 type program struct {
 	logger    *zap.Logger
@@ -203,6 +206,7 @@ func main() {
 					hostAgent := agent.NewHostAgent(
 						cfg,
 						agent.WithHostAgentLogger(logger),
+						agent.WithHostAgentVersion(agentVersion),
 						agent.WithHostAgentOtelConfigDirectory(installDir),
 					)
 
@@ -321,6 +325,14 @@ func main() {
 					if err != nil {
 						logger.Error("error after running the service", zap.Error(err))
 					}
+					return nil
+				},
+			},
+			{
+				Name:  "version",
+				Usage: "Returns the current agent version",
+				Action: func(c *cli.Context) error {
+					fmt.Println("Middleware Agent Version", agentVersion)
 					return nil
 				},
 			},

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -27,10 +27,17 @@ type HostAgent struct {
 	HostConfig
 	logger              *zap.Logger
 	otelConfigDirectory string
+	Version             string
 }
 
 // HostOptions takes in various options for HostAgent
 type HostOptions func(h *HostAgent)
+
+func WithHostAgentVersion(v string) HostOptions {
+	return func(h *HostAgent) {
+		h.Version = v
+	}
+}
 
 // WithHostAgentLogger sets the logger to be used with agent logs
 func WithHostAgentLogger(logger *zap.Logger) HostOptions {
@@ -190,6 +197,7 @@ func (c *HostAgent) updateYAML(configType, yamlPath string) error {
 	params.Add("platform", runtime.GOOS)
 	params.Add("host_id", hostname)
 	params.Add("host_tags", c.HostTags)
+	params.Add("agent_version", c.Version)
 	// Add Query Parameters to the URL
 	baseURL.RawQuery = params.Encode() // Escape Query Parameters
 	resp, err := http.Get(baseURL.String())
@@ -324,6 +332,7 @@ func (c *HostAgent) callRestartStatusAPI() error {
 	params := url.Values{}
 	params.Add("host_id", hostname)
 	params.Add("platform", runtime.GOOS)
+	params.Add("agent_version", c.Version)
 
 	// Add Query Parameters to the URL
 	baseURL.RawQuery = params.Encode() // Escape Query Parameters


### PR DESCRIPTION
1. Go build example with ldflags

```
go build -o mw-host-agent -ldflags "-X main.agentVersion=1.0.3" cmd/host-agent/main.go
```

2. Setting CGO_ENABLED=0 for windows as well, so that agent is independent from host c libs