### PR TITLE
attribute renamed for log-metrics mapping in k8s.pod and k8s.containers

### DIFF
--- a/configyamls-k8s/otel-config-nodocker.yaml
+++ b/configyamls-k8s/otel-config-nodocker.yaml
@@ -46,7 +46,7 @@ receivers:
       # Extract metadata from file path
       - type: regex_parser
         id: extract_metadata_from_filepath
-        regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+        regex: '^.*\/(?P<namespace>[^_]+)_(?P<k8s.pod.name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<k8s.container.name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
         parse_from: attributes["log.file.path"]
         output: move_log_to_body
       - type: move
@@ -314,10 +314,10 @@ processors:
         from_attribute: projectName
         action: upsert
       - key: source
-        from_attribute: pod_name
+        from_attribute: k8s.pod.name
         action: upsert
       - key: source
-        from_attribute: container_name
+        from_attribute: k8s.container.name
         action: upsert
       - key: source
         from_attribute: namespace

--- a/configyamls-k8s/otel-config.yaml
+++ b/configyamls-k8s/otel-config.yaml
@@ -46,7 +46,7 @@ receivers:
       # Extract metadata from file path
       - type: regex_parser
         id: extract_metadata_from_filepath
-        regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+        regex: '^.*\/(?P<namespace>[^_]+)_(?P<k8s.pod.name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<k8s.container.name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
         parse_from: attributes["log.file.path"]
         output: move_log_to_body
       # Fetching only body content from key 'log'
@@ -327,10 +327,10 @@ processors:
         from_attribute: projectName
         action: upsert
       - key: source
-        from_attribute: pod_name
+        from_attribute: k8s.pod.name
         action: upsert
       - key: source
-        from_attribute: container_name
+        from_attribute: k8s.container.name
         action: upsert
       - key: source
         from_attribute: namespace


### PR DESCRIPTION
Renamed attribute names, so that 
k8s pods logs and k8s pod metrics can be mapped