### PR TITLE
considering host.name from host agent forcefully

### DIFF
--- a/configyamls/all/otel-config.yaml
+++ b/configyamls/all/otel-config.yaml
@@ -63,21 +63,20 @@ processors:
       from_attribute: faas.trigger
       key: mw.service.name.derived
   batch: null
-  resource:
+  resource/metrics:
     attributes:
     - action: upsert
       key: mw.account_key
       value: ${MW_API_KEY}
-    - action: upsert
-      from_attribute: host.name
-      key: host.id
+    - action: delete
+      key: host.name
     - action: insert
       from_attribute: host.name
       key: agent.installation.time
     - action: update
       key: agent.installation.time
       value: ${MW_AGENT_INSTALLATION_TIME}
-  resource/2:
+  resource/logs:
     attributes:
     - action: upsert
       key: mw.account_key
@@ -85,17 +84,20 @@ processors:
     - action: insert
       key: service.name
       value: middleware-logs
-    - action: upsert
-      from_attribute: host.name
-      key: host.id
-  resource/3:
+    - action: delete
+      key: host.name
+  resource/traces:
     attributes:
     - action: upsert
       key: mw.account_key
       value: ${MW_API_KEY}
-    - action: upsert
-      from_attribute: host.name
-      key: host.id
+    - action: delete
+      key: host.name
+  resource/hostid:
+    attributes:
+        - key: host.id
+          action: upsert
+          from_attribute: host.name
   resourcedetection:
     detectors:
     - env
@@ -207,8 +209,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/logs
       - resourcedetection
-      - resource/2
+      - resource/hostid
       - attributes/logs
       - batch
       receivers:
@@ -218,8 +221,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/metrics
       - resourcedetection
-      - resource
+      - resource/hostid
       - batch
       receivers:
       - hostmetrics
@@ -230,8 +234,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/traces
       - resourcedetection
-      - resource/3
+      - resource/hostid
       - attributes/traces
       - batch
       receivers:

--- a/configyamls/nodocker/otel-config.yaml
+++ b/configyamls/nodocker/otel-config.yaml
@@ -7,21 +7,20 @@ processors:
     #             bodies:
     #             - \n
     #             - {}\n
-    resource:
+    resource/metrics:
         attributes:
             - key: mw.account_key
               action: upsert
               value: ${MW_API_KEY}
-            - key: host.id
-              action: upsert
-              from_attribute: host.name
+            - action: delete
+              key: host.name
             - key: agent.installation.time
               action: insert
               from_attribute: host.name
             - key: agent.installation.time
               action: update
               value: ${MW_AGENT_INSTALLATION_TIME}
-    resource/2:
+    resource/logs:
         attributes:
             - key: mw.account_key
               action: upsert
@@ -29,14 +28,17 @@ processors:
             - key: service.name
               action: insert
               value: middleware-logs
-            - key: host.id
-              action: upsert
-              from_attribute: host.name
-    resource/3:
+            - action: delete
+              key: host.name
+    resource/traces:
         attributes:
             - key: mw.account_key
               action: upsert
               value: ${MW_API_KEY}
+            - action: delete
+              key: host.name
+    resource/hostid:
+        attributes:
             - key: host.id
               action: upsert
               from_attribute: host.name
@@ -203,8 +205,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/logs
       - resourcedetection
-      - resource/2
+      - resource/hostid
       - attributes/logs
       - batch
       receivers:
@@ -214,8 +217,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/metrics
       - resourcedetection
-      - resource
+      - resource/hostid
       - batch
       receivers:
       - hostmetrics
@@ -225,8 +229,9 @@ service:
       exporters:
       - otlp/2
       processors:
+      - resource/traces
       - resourcedetection
-      - resource/3
+      - resource/hostid
       - attributes/traces
       - batch
       receivers:


### PR DESCRIPTION
1. Renaming ... for ease of understanding
```
resource => resource/metrics
resource/2 => resource/logs
resource/3 => resource/traces
```
2. Deleting host.name received from language specific SDKs, considering host.name from resourcedetectionprocessor only. 