### PR TITLE
Add capability to autodetect config check url from target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-linux:
 	GOOS=linux CGO_ENABLED=0 go build -o build/mw-host-agent cmd/host-agent/main.go
 
 build-kube:
-	GOOS=linux CGO_ENABLED=0 go build -o build/mw-host-agent cmd/kube-agent/main.go
+	GOOS=linux CGO_ENABLED=0 go build -o build/mw-kube-agent cmd/kube-agent/main.go
 build: build-linux build-windows build-kube
 
 #package-windows only works on Linux

--- a/cmd/kube-agent/main.go
+++ b/cmd/kube-agent/main.go
@@ -62,13 +62,7 @@ func getFlags(cfg *agent.KubeConfig) []cli.Flag {
 			DefaultText: "unix:///var/run/docker.sock",
 			Value:       "unix:///var/run/docker.sock",
 		}),
-		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:        "api-url-for-config-check",
-			EnvVars:     []string{"MW_API_URL_FOR_CONFIG_CHECK"},
-			Destination: &cfg.APIURLForConfigCheck,
-			DefaultText: "https://app.middleware.io",
-			Hidden:      true,
-		}),
+
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        "insight-refresh-duration",
 			EnvVars:     []string{"MW_INSIGHT_REFRESH_DURATION"},

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -24,6 +25,10 @@ const (
 	Service                = "service"
 	Pipelines              = "pipelines"
 	Metrics                = "metrics"
+)
+
+var (
+	ErrInvalidTarget = fmt.Errorf("invalid target")
 )
 
 // InfraPlatform defines the agent's infrastructure platform
@@ -135,4 +140,26 @@ func getHostname() string {
 		return ""
 	}
 	return hostname
+}
+
+func GetAPIURLForConfigCheck(target string) (string, error) {
+	url := strings.TrimRight(target, "/")
+
+	// There should at least be two "." in the URL
+	parts := strings.Split(url, ".")
+	if len(parts) < 3 {
+		return "", ErrInvalidTarget
+	}
+
+	// Find the index of the last "/" and first "."
+	firstSlash := strings.LastIndex(url, "/")
+	firstDot := strings.Index(url, ".")
+
+	// Check if both "/" and "." exist in the URL
+	if firstSlash != -1 && firstDot != -1 {
+		// Replace the string between "/" and the first "."
+		return url[:firstSlash+1] + "app" + url[firstDot:], nil
+	}
+
+	return "", ErrInvalidTarget
 }

--- a/pkg/agent/definitions_test.go
+++ b/pkg/agent/definitions_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAPIURLForConfigCheck(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		expectedResult string
+		err            error
+	}{
+		{
+			name:           "URL with both '/' and '.' and without trailing '/'",
+			url:            "https://myaccount.middleware.io",
+			expectedResult: "https://app.middleware.io",
+			err:            nil,
+		},
+		{
+			name:           "URL with trailing '/'",
+			url:            "https://myaccount.middleware.io/",
+			expectedResult: "https://app.middleware.io",
+			err:            nil,
+		},
+		{
+			name:           "URL with only one '.'",
+			url:            "https://middleware.io",
+			expectedResult: "",
+			err:            ErrInvalidTarget,
+		},
+		{
+			name:           "URL with custom domain",
+			url:            "https://myaccount.test.mw.io",
+			expectedResult: "https://app.test.mw.io",
+			err:            nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := GetAPIURLForConfigCheck(test.url)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -58,6 +58,7 @@ func WithHostAgentInfraPlatform(p InfraPlatform) HostOptions {
 func NewHostAgent(cfg HostConfig, opts ...HostOptions) *HostAgent {
 	var agent HostAgent
 	agent.HostConfig = cfg
+
 	for _, apply := range opts {
 		apply(&agent)
 	}

--- a/pkg/agent/hostagent_test.go
+++ b/pkg/agent/hostagent_test.go
@@ -176,7 +176,15 @@ func TestListenForConfigChanges(t *testing.T) {
 }
 
 func TestHostAgentGetFactories(t *testing.T) {
-	agent := NewHostAgent(HostConfig{},
+	baseConfig := BaseConfig{
+		AgentFeatures: AgentFeatures{
+			InfraMonitoring: true,
+		},
+	}
+
+	agent := NewHostAgent(HostConfig{
+		BaseConfig: baseConfig,
+	},
 		WithHostAgentLogger(zap.NewNop()),
 		WithHostAgentInfraPlatform(InfraPlatformECSEC2))
 
@@ -194,7 +202,7 @@ func TestHostAgentGetFactories(t *testing.T) {
 	assert.Contains(t, factories.Extensions, component.Type("health_check"))
 
 	// check if factories contains expected receivers
-	assert.Len(t, factories.Receivers, 11)
+	assert.Len(t, factories.Receivers, 12)
 	assert.Contains(t, factories.Receivers, component.Type("otlp"))
 	assert.Contains(t, factories.Receivers, component.Type("fluentforward"))
 	assert.Contains(t, factories.Receivers, component.Type("filelog"))
@@ -205,6 +213,7 @@ func TestHostAgentGetFactories(t *testing.T) {
 	assert.Contains(t, factories.Receivers, component.Type("mongodb"))
 	assert.Contains(t, factories.Receivers, component.Type("mysql"))
 	assert.Contains(t, factories.Receivers, component.Type("redis"))
+	assert.Contains(t, factories.Receivers, component.Type("elasticsearch"))
 	assert.Contains(t, factories.Receivers, component.Type("awsecscontainermetrics"))
 
 	// check if factories contain expected exporters


### PR DESCRIPTION

Config check URL can be auto-detected from target URL. In case, user explicitly passes the URL, we will honor that and not detect it from the target.

Added unit test cases for this functionality and also fixed some broken unit test cases.