### PR TITLE
Update workflow to create deb file to use xz compression to support older debian/ubuntu

### DIFF
--- a/.github/workflows/host-agent-deb-apt.yaml
+++ b/.github/workflows/host-agent-deb-apt.yaml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Creating DEB package
       run: |
-          dpkg --build build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}
+          dpkg-deb --build -Z xz build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}
           dpkg-deb --info build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}.deb
           dpkg-deb --contents build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}.deb
 


### PR DESCRIPTION
New `dpkg` version defaults to `zstd` compression for deb packages which is not supported in Debian 11 and Ubuntu 20.04