### PR TITLE
Add ability to configure agent metric port and add host tags during Linux installation

### DIFF
--- a/package-tooling/agent-config.yaml.sample
+++ b/package-tooling/agent-config.yaml.sample
@@ -6,11 +6,6 @@ api-key:
 # target is your unique Middleware account URL
 target: 
 
-# Synthetic monitoring using the Middleware agent is disabled by default.
-# Set enable-synthetic-monitoring to true if you want this agent to be
-# able to perform synthetic tests.
-enable-synthetic-monitoring: false
-
 # The duration for the agent to check for configuration changes from the
 # backend. We recommend to keep this change to 5 minutes or higher. Keeping 
 # this duration to a smaller value will impact resource consumption on the
@@ -18,8 +13,15 @@ enable-synthetic-monitoring: false
 config-check-interval: "5m"
 
 # The tags required to identify / categorize the host in the Middleware UI.
-# The tags are comma separated key:value pairs.
+# The tags are comma separated key:value pairs. Empty host-tag should always
+# be a double quoted string ("").
+# Examples:
+# host-tags: "" 
 # host-tags: "name:my-machine,env:production"
+host-tags: ""
+
+# This is the port where MW Agent exposes its internal metrics.
+agent-internal-metrics-port: 8888
 
 # log file to store agent logs in a given file. If left empty,
 # the logs will be directed to stdout & stderr. 
@@ -33,5 +35,5 @@ config-check-interval: "5m"
 #
 # infra-monitoring: By setting this flag to false, you can disable infrastructure
 # monitoring from this agent. infra-monitoring is set to true by default.
-#agent-features:
+# agent-features:
 #  infra-monitoring: false

--- a/package-tooling/linux/postinst
+++ b/package-tooling/linux/postinst
@@ -20,6 +20,7 @@ restart_service() {
 }
 
 # Function to update configuration values
+
 update_config() {
     local key=$1
     local value=$2
@@ -27,9 +28,20 @@ update_config() {
 
     # Update configuration file with the provided key and value
     sed -i "s|^\s*${key}:.*|${key}: ${value}|" "$file"
+    
     if [ $? -ne 0 ]; then
         echo "Error: Failed to update configuration file."
         exit 1
+    fi
+
+    # Check if the key was updated. If not, append the key-value pair to the file.
+    grep -q "^\s*${key}:" "$file"
+    if [ $? -ne 0 ]; then
+        echo "${key}: ${value}" >> "$file"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to append to configuration file."
+            exit 1
+        fi
     fi
 }
 
@@ -56,15 +68,26 @@ handle_variable() {
         MW_TARGET)
             update_config "target" "$value" "${CONFIG_FILE}"
             ;;
-        MW_ENABLE_SYNTHETIC_MONITORING)
-            update_config "enable-synthetic-monitoring" "$value" "${CONFIG_FILE}"
-            ;;
         MW_CONFIG_CHECK_INTERVAL)
             update_config "config-check-interval" "$value" "${CONFIG_FILE}"
             ;;
+        MW_HOST_TAGS)
+            update_config "host-tags" "$value" "${CONFIG_FILE}"
+            ;;
+        MW_AGENT_INTERNAL_METRICS_PORT)
+            update_config "agent-internal-metrics-port" "$value" "${CONFIG_FILE}"
+            ;;
+        # Advanced configuration options
         MW_API_URL_FOR_CONFIG_CHECK)
             update_config "api-url-for-config-check" "$value" "${CONFIG_FILE}"
             ;;
+        MW_FETCH_ACCOUNT_OTEL_CONFIG)
+            update_config "fetch-account-otel-config" "$value" "${CONFIG_FILE}"
+            ;; 
+        MW_ENABLE_SYNTHETIC_MONITORING)
+            # synthetic monitoring feature has been removed from the agent
+            ;;
+        
         PATH)
             ;;
         *)
@@ -145,6 +168,31 @@ else
         # Update configuration file with environment variable values
         handle_variable "MW_API_KEY" "${MW_API_KEY}"
         handle_variable "MW_TARGET" "${MW_TARGET}"
+
+        if [ -n "${MW_CONFIG_CHECK_INTERVAL}" ]; then
+            handle_variable "MW_CONFIG_CHECK_INTERVAL" "${MW_CONFIG_CHECK_INTERVAL}"
+        fi
+
+        if [ -n "${MW_HOST_TAGS}" ]; then
+            handle_variable "MW_HOST_TAGS" "${MW_HOST_TAGS}"
+        fi
+
+        if [ -n "${MW_AGENT_INTERNAL_METRICS_PORT}" ]; then
+            handle_variable "MW_AGENT_INTERNAL_METRICS_PORT" "${MW_AGENT_INTERNAL_METRICS_PORT}"
+        fi
+
+        if [ -n "${MW_API_URL_FOR_CONFIG_CHECK}" ]; then
+            handle_variable "MW_API_URL_FOR_CONFIG_CHECK" "${MW_API_URL_FOR_CONFIG_CHECK}"
+        fi
+
+        if [ -n "${MW_ENABLE_SYNTHETIC_MONITORING}" ]; then
+            handle_variable "MW_ENABLE_SYNTHETIC_MONITORING" "${MW_ENABLE_SYNTHETIC_MONITORING}"
+        fi 
+
+        if [ -n "${MW_FETCH_ACCOUNT_OTEL_CONFIG}" ]; then
+            handle_variable "MW_FETCH_ACCOUNT_OTEL_CONFIG" "${MW_FETCH_ACCOUNT_OTEL_CONFIG}"
+        fi
+        
     fi
 fi
 

--- a/package-tooling/otel-config.yaml.sample
+++ b/package-tooling/otel-config.yaml.sample
@@ -198,7 +198,7 @@ receivers:
         scrape_interval: 5s
         static_configs:
         - targets:
-          - 127.0.0.1:8888
+          - 127.0.0.1:${MW_AGENT_INTERNAL_METRICS_PORT}
 service:
   pipelines:
     logs:
@@ -239,5 +239,7 @@ service:
       receivers:
       - otlp
   telemetry:
+    metrics:
+      address: 127.0.0.1:${MW_AGENT_INTERNAL_METRICS_PORT}
     logs:
       level: fatal

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -81,6 +81,7 @@ type BaseConfig struct {
 	AgentFeatures             AgentFeatures
 	SelfProfiling             bool
 	ProfilngServerURL         string
+	InternalMetricsPort       uint
 }
 
 // String() implements stringer interface for BaseConfig


### PR DESCRIPTION
With this change, users can change the default agent telemetry port from `8888` to a custom defined one. 

Also added fix for supporting `MW_HOST_TAGS` environment variable during Linux agent installation.