### PR TITLE
Setting up fallback namespace

### DIFF
--- a/cmd/kube-agent/main.go
+++ b/cmd/kube-agent/main.go
@@ -262,9 +262,14 @@ func main() {
 					ctx, cancel := context.WithCancel(c.Context)
 					defer cancel()
 
+					mwNamespace := os.Getenv("MW_NAMESPACE")
+					if mwNamespace == "" {
+						mwNamespace = "mw-agent-ns"
+					}
+
 					kubeAgentMonitor := agent.NewKubeAgentMonitor(cfg,
 						agent.WithKubeAgentMonitorClusterName(os.Getenv("MW_KUBE_CLUSTER_NAME")),
-						agent.WithKubeAgentMonitorAgentNamespace(os.Getenv("MW_NAMESPACE")),
+						agent.WithKubeAgentMonitorAgentNamespace(mwNamespace),
 						agent.WithKubeAgentMonitorDaemonset("mw-kube-agent"),
 						agent.WithKubeAgentMonitorDeployment("mw-kube-agent"),
 						agent.WithKubeAgentMonitorDaemonsetConfigMap("mw-daemonset-otel-config"),


### PR DESCRIPTION
K8s agent may not restart for users if MW_NAMESPACE is not set, Therefore adding a fallback namespace

Logs received from one of our client clusters:

```
{"level":"INFO","time":"2024-05-28T16:16:01.133Z","caller":"kube-agent/main.go:129","message":"MW_ISSET_AGENT_INSTALLATION_TIME env variable does not exists"}

{"level":"info","ts":1716912961.4956152,"caller":"agent/kubeagent.go:235","msg":"restarting mw-agent"}

{"level":"error","ts":1716912961.6204927,"caller":"agent/kubeagent.go:389","msg":"Error getting ConfigMap: %v\nan empty namespace may not be set when a resource name is provided","stacktrace":"github.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).updateConfigMap\n\t/app/pkg/agent/kubeagent.go:389\ngithub.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).restartKubeAgent\n\t/app/pkg/agent/kubeagent.go:256\ngithub.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).callRestartStatusAPI\n\t/app/pkg/agent/kubeagent.go:236\ngithub.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).ListenForKubeOtelConfigChanges\n\t/app/pkg/agent/kubeagent.go:187\nmain.main.func3\n\t/app/cmd/kube-agent/main.go:281\ngithub.com/urfave/cli/v2.(*Command).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274\ngithub.com/urfave/cli/v2.(*Command).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267\ngithub.com/urfave/cli/v2.(*App).RunContext\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332\ngithub.com/urfave/cli/v2.(*App).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:309\nmain.main\n\t/app/cmd/kube-agent/main.go:293\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:271"}

{"level":"error","ts":1716912961.6205704,"caller":"agent/kubeagent.go:237","msg":"error restarting mw-agent daemonset","error":"an empty namespace may not be set when a resource name is provided","stacktrace":"github.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).callRestartStatusAPI\n\t/app/pkg/agent/kubeagent.go:237\ngithub.com/middleware-labs/mw-agent/pkg/agent.(*KubeAgentMonitor).ListenForKubeOtelConfigChanges\n\t/app/pkg/agent/kubeagent.go:187\nmain.main.func3\n\t/app/cmd/kube-agent/main.go:281\ngithub.com/urfave/cli/v2.(*Command).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274\ngithub.com/urfave/cli/v2.(*Command).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267\ngithub.com/urfave/cli/v2.(*App).RunContext\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332\ngithub.com/urfave/cli/v2.(*App).Run\n\t/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:309\nmain.main\n\t/app/cmd/kube-agent/main.go:293\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:271"}

{"level":"info","ts":1716912961.6206052,"caller":"agent/kubeagent.go:189","msg":"error restarting agent on config change","error":"an empty namespace may not be set when a resource name is provided"}
```