### PR TITLE
Add ability to start/stop telemetry collection dynamically

### DIFF
--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -106,9 +106,10 @@ func (c BaseConfig) String() string {
 type HostConfig struct {
 	BaseConfig
 
-	HostTags    string
-	Logfile     string
-	LogfileSize int
+	HostTags     string
+	Logfile      string
+	LogfileSize  int
+	LoggingLevel string
 }
 
 // String() implements stringer interface for HostConfig

--- a/pkg/agent/hostagent_linux.go
+++ b/pkg/agent/hostagent_linux.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"


### PR DESCRIPTION
`mw-agent` should be able to start/stop telemetry collection and export dynamically.

There are several cases where this might be needed.

- If API token is invalid, stop collection and export of telemetry data.
- If Middleware backend is unreachable, stop collection and export of telemetry data until Middleware backend is reachable again.
- If Otel config is invalid, don't stop mw-agent, but just stop the telemetry collection. Other features like synthetic checks can continue even if Otel config is invalid.

Also, added `logging-level`  (env `LOGGING_LEVEL`) to set `mw-agent` logging level. 
