### PR TITLE
Changed Upload Job in Deb and Token in windows workflow

### DIFF
--- a/.github/workflows/test-deb-workflow.yaml
+++ b/.github/workflows/test-deb-workflow.yaml
@@ -113,7 +113,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: mw-agent-${{ matrix.arch }}-deb
-        path: build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}.deb
+        path: build/mw-agent_${{ env.RELEASE_VERSION }}_${{ matrix.arch }}.deb
         retention-days: 1
 
     # - name: Set up aptly

--- a/.github/workflows/test-windows-workflow.yaml
+++ b/.github/workflows/test-windows-workflow.yaml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Upload to release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN}}
       run: |
         VERSION="${{ github.event.inputs.release_version }}"
         if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Fixed a miss in windows workflow.

Changed upload job in deb workflow.
Found the issue:
```
- name: Upload DEB as artifact
      uses: actions/upload-artifact@v3
      with:
        name: mw-agent-${{ matrix.arch }}-deb
        path: build/${PACKAGE_NAME}_${RELEASE_VERSION}_${{ matrix.arch }}.deb #The vars here were not expanding
        retention-days: 1
```
Changed it to:
```
- name: Upload DEB as artifact
      uses: actions/upload-artifact@v3
      with:
        name: mw-agent-${{ matrix.arch }}-deb
        path: build/mw-agent_${{ env.RELEASE_VERSION }}_${{ matrix.arch }}.deb
        retention-days: 1
```