### PR TITLE
AGE-179, AGE-124 : Adding Support for mw.host.tag resource attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter => github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.91.1-0.20241220064255-38b7463368b2
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl => github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20241220064255-38b7463368b2
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl => github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20250224071852-491f9ff47aa8
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.91.1-0.20241220064255-38b7463368b2
 

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,8 @@ github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xV
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.91.1-0.20241220064255-38b7463368b2 h1:rN5D1MrHz6keh/6Ov27oktIpRwH7YRxuCFqYG1XMybs=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.91.1-0.20241220064255-38b7463368b2/go.mod h1:6QU/K0dGCGYorkOvJmhbDFCspy4RPxRkFjf9I64y6I0=
-github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20241220064255-38b7463368b2 h1:PUojVFgQU5DaajePIxm0OTEwpL10MUezkZZ1MEuR3xs=
-github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20241220064255-38b7463368b2/go.mod h1:mrL1MNrcg0zYAJ+aK9WtOH062dl2wN9DDG7mZk9H8v4=
+github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20250224071852-491f9ff47aa8 h1:aokGVjS5OgaTQ+hKDlFnB4xNFmyajOmGJXGwFb0MNPU=
+github.com/middleware-labs/opentelemetry-collector-contrib/pkg/ottl v0.91.1-0.20250224071852-491f9ff47aa8/go.mod h1:mrL1MNrcg0zYAJ+aK9WtOH062dl2wN9DDG7mZk9H8v4=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/apachereceiver v0.91.1-0.20241220064255-38b7463368b2 h1:neECqyBhWf3ZtsXcUR/b4bLlhuGGmInOR7VC3EfTZAA=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/apachereceiver v0.91.1-0.20241220064255-38b7463368b2/go.mod h1:w/uUF3wkSldjm47A9c6dVuXBHKdxnnOchgd6/Bk+1bo=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.91.1-0.20241220064255-38b7463368b2 h1:nk5UB1pBFFSqA/EtJkJA4Mf3ff6AC0VqiAszS/FSqwc=

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -24,6 +24,7 @@ type Agent interface {
 // Otel config components
 const (
 	Receivers              = "receivers"
+	Processors             = "processors"
 	AWSECSContainerMetrics = "awsecscontainermetrics"
 	Service                = "service"
 	Pipelines              = "pipelines"

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -120,11 +120,12 @@ func NewHostAgent(cfg HostConfig, zapCore zapcore.Core,
 }
 
 var (
-	ErrKeyNotFound    = fmt.Errorf("'%s' key not found", Receivers)
-	ErrParseReceivers = fmt.Errorf("failed to parse %s in otel config file", Receivers)
-	ErrParseService   = fmt.Errorf("failed to parse %s in otel config file", Service)
-	ErrParsePipelines = fmt.Errorf("failed to parse %s in otel config file", Pipelines)
-	ErrParseMetrics   = fmt.Errorf("failed to parse %s in otel config file", Metrics)
+	ErrKeyNotFound     = fmt.Errorf("'%s' key not found", Receivers)
+	ErrParseReceivers  = fmt.Errorf("failed to parse %s in otel config file", Receivers)
+	ErrParseProcessors = fmt.Errorf("failed to parse %s in otel config file", Processors)
+	ErrParseService    = fmt.Errorf("failed to parse %s in otel config file", Service)
+	ErrParsePipelines  = fmt.Errorf("failed to parse %s in otel config file", Pipelines)
+	ErrParseMetrics    = fmt.Errorf("failed to parse %s in otel config file", Metrics)
 )
 
 type configType struct {
@@ -435,6 +436,14 @@ func (c *HostAgent) updateConfigFile(configType string) error {
 
 	if !c.AgentFeatures.LogCollection || !c.AgentFeatures.MetricCollection {
 		apiYAMLConfig, err = c.updateConfigWithRestrictions(apiYAMLConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Adding host tags as resource attributes
+	if c.HostTags != "" {
+		apiYAMLConfig, err = c.updateConfigForHostTags(apiYAMLConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/agent/hosttags.go
+++ b/pkg/agent/hosttags.go
@@ -1,0 +1,61 @@
+package agent
+
+func (c *HostAgent) updateConfigForHostTags(config map[string]interface{}) (map[string]interface{}, error) {
+
+	processorsData, ok := config[Processors].(map[string]interface{})
+	if !ok {
+		return nil, ErrParseProcessors
+	}
+
+	processorsData["resource/host_tags"] = map[string]interface{}{
+		"attributes": []map[string]interface{}{
+			{
+				"key":    "mw.host.tags",
+				"action": "insert",
+				"value":  c.HostTags,
+			},
+		},
+	}
+
+	serviceData, ok := config[Service].(map[string]interface{})
+	if !ok {
+		return nil, ErrParseService
+	}
+
+	pipelinesData, ok := serviceData[Pipelines].(map[string]interface{})
+	if !ok {
+		return nil, ErrParsePipelines
+	}
+
+	// Iterate over each pipeline and add the processor
+	for pipelineName, pipeline := range pipelinesData {
+		pipelineMap, ok := pipeline.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Get existing processors
+		processors, exists := pipelineMap["processors"].([]interface{})
+		if !exists {
+			// If processors do not exist, create a new slice
+			pipelineMap["processors"] = []interface{}{"resource/host_tags"}
+		} else {
+			// Append "resource/host_tags" only if it's not already present
+			found := false
+			for _, p := range processors {
+				if p == "resource/host_tags" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				pipelineMap["processors"] = append([]interface{}{"resource/host_tags"}, processors...)
+			}
+		}
+
+		// Update the pipeline back
+		pipelinesData[pipelineName] = pipelineMap
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
Agent will modify the local `otel-config` file to set `mw.host.tag` resource attribute, if host tags are provided via ..
1. Config file
2. ENV 
3. Inline argument