### PR TITLE
milan03-mw/AGE-409: Pipeline merge all 3 into one (Agent, Backend and Ingestion groups)

### DIFF
--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -44,6 +44,7 @@ type HostAgent struct {
 	logger              *zap.Logger
 	httpGetFunc         func(url string) (resp *http.Response, err error)
 	Version             string
+	applyConfigOnce     sync.Once
 }
 
 // HostOptions takes in various options for HostAgent
@@ -202,9 +203,10 @@ type TrackingPayload struct {
 }
 
 var (
-	apiPathForYAML    = "api/v1/agent/ingestion-rules"
-	apiPathForRestart = "api/v1/agent/restart-status"
-	apiAgentTrack     = "api/v1/agent/tracking"
+	apiPathForYAML         = "api/v1/agent/ingestion-rules"
+	apiPathForRestart      = "api/v1/agent/restart-status"
+	apiAgentTrack          = "api/v1/agent/tracking"
+	apiPathForConfigGroups = "api/v1/agent/public/setting/config-groups" // Apply config class to hosts
 )
 
 func (d IntegrationType) String() string {
@@ -616,6 +618,65 @@ func (c *HostAgent) callRestartStatusAPI() error {
 	return err
 }
 
+func (c *HostAgent) applyConfigClassToHosts() error {
+	hostname := GetHostnameForPlatform(c.InfraPlatform)
+	u, err := url.Parse(c.APIURLForConfigCheck)
+	if err != nil {
+		return err
+	}
+
+	// Build the URL: /agent/public/setting/config-groups/{groupName}/{token}
+	baseURL := u.JoinPath(apiPathForConfigGroups)
+	baseURL = baseURL.JoinPath(c.APIKey)
+	baseURL = baseURL.JoinPath("default")
+
+	// Prepare request body
+	reqBody := map[string][]string{
+		"hostIds": {hostname},
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(http.MethodPut, baseURL.String(), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call config groups api for url %s: %w", baseURL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("config groups api returned non-200 status: %d", resp.StatusCode)
+	}
+
+	var apiResponse struct {
+		Status  bool        `json:"status"`
+		Message string      `json:"message"`
+		Setting interface{} `json:"setting"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
+		return fmt.Errorf("failed to unmarshal config groups api response: %w", err)
+	}
+
+	if !apiResponse.Status {
+		return fmt.Errorf("config groups api returned error: %s", apiResponse.Message)
+	}
+
+	c.logger.Info("successfully applied config class to host",
+		zap.String("group_name", "default"),
+		zap.String("host_id", hostname))
+
+	return nil
+}
+
 // ListenForConfigChanges listens for configuration changes for the
 // agent on the Middleware backend and restarts the agent if configuration
 // has changed.
@@ -641,6 +702,14 @@ func (c *HostAgent) ListenForConfigChanges(errCh chan<- error,
 			return nil
 		case <-ticker.C:
 			err = c.callRestartStatusAPI()
+			if err == nil {
+				// If restart check succeeded, try to apply config class (only once)
+				c.applyConfigOnce.Do(func() {
+					if applyErr := c.applyConfigClassToHosts(); applyErr != nil {
+						c.logger.Error("failed to apply config class", zap.Error(applyErr))
+					}
+				})
+			}
 			errCh <- err
 		}
 	}

--- a/pkg/agent/kubeagent.go
+++ b/pkg/agent/kubeagent.go
@@ -225,7 +225,7 @@ func (k *KubeAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 func (c *KubeAgentMonitor) ListenForKubeOtelConfigChanges(ctx context.Context) error {
 	err := c.callRestartStatusAPI(ctx)
 	if err != nil {
-		c.logger.Info("error restarting agent on config change",
+		c.logger.Error("error restarting agent on config change",
 			zap.Error(err))
 	}
 	return nil

--- a/pkg/configupdater/definitions.go
+++ b/pkg/configupdater/definitions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -67,8 +68,9 @@ type configType struct {
 }
 
 var (
-	apiPathForYAML    = "api/v1/agent/ingestion-rules"
-	apiPathForRestart = "api/v1/agent/restart-status"
+	apiPathForYAML         = "api/v1/agent/ingestion-rules"
+	apiPathForRestart      = "api/v1/agent/restart-status"
+	apiPathForConfigGroups = "api/v1/agent/public/setting/config-groups" // Apply config class to cluster
 )
 
 type apiResponseForYAML struct {
@@ -139,6 +141,7 @@ type KubeAgent struct {
 	configCheckDuration time.Duration
 	logger              *zap.Logger
 	version             string
+	applyConfigOnce     sync.Once
 }
 
 func GetAPIURLForConfigCheck(target string) (string, error) {

--- a/pkg/configupdater/kubeagentupdater.go
+++ b/pkg/configupdater/kubeagentupdater.go
@@ -1,6 +1,7 @@
 package configupdater
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -78,7 +79,16 @@ func (c *KubeAgent) ListenForConfigChanges(ctx context.Context, errCh chan<- err
 			ticker.Stop()
 			return nil
 		case <-ticker.C:
-			errCh <- c.callRestartStatusAPI(ctx, false)
+			err := c.callRestartStatusAPI(ctx, false)
+			if err == nil {
+				// If restart check succeeded, try to apply config class (only once)
+				c.applyConfigOnce.Do(func() {
+					if applyErr := c.applyConfigClassToCluster(); applyErr != nil {
+						c.logger.Error("failed to apply config class", zap.Error(applyErr))
+					}
+				})
+			}
+			errCh <- err
 		}
 	}
 }
@@ -319,5 +329,63 @@ func (c *KubeAgent) UpdateConfigMap(ctx context.Context, componentType Component
 	}
 
 	return nil
+}
 
+// applyConfigClassToCluster applies config class to the Kubernetes cluster
+func (c *KubeAgent) applyConfigClassToCluster() error {
+	u, err := url.Parse(c.APIURLForConfigCheck)
+	if err != nil {
+		return err
+	}
+
+	// Build the URL: /agent/public/setting/config-groups/{groupName}/{token}
+	baseURL := u.JoinPath(apiPathForConfigGroups)
+	baseURL = baseURL.JoinPath(c.APIKey)
+	baseURL = baseURL.JoinPath("default")
+
+	// Prepare request body
+	reqBody := map[string][]string{
+		"hostIds": {c.ClusterName},
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(http.MethodPut, baseURL.String(), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call config groups api for url %s: %w", baseURL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("config groups api returned non-200 status: %d", resp.StatusCode)
+	}
+
+	var apiResponse struct {
+		Status  bool        `json:"status"`
+		Message string      `json:"message"`
+		Setting interface{} `json:"setting"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
+		return fmt.Errorf("failed to unmarshal config groups api response: %w", err)
+	}
+
+	if !apiResponse.Status {
+		return fmt.Errorf("config groups api returned error: %s", apiResponse.Message)
+	}
+
+	c.logger.Info("successfully applied config class to cluster",
+		zap.String("group_name", "default"),
+		zap.String("cluster_id", c.ClusterName))
+
+	return nil
 }

--- a/pkg/configupdater/kubeagentupdater.go
+++ b/pkg/configupdater/kubeagentupdater.go
@@ -80,14 +80,13 @@ func (c *KubeAgent) ListenForConfigChanges(ctx context.Context, errCh chan<- err
 			return nil
 		case <-ticker.C:
 			err := c.callRestartStatusAPI(ctx, false)
-			if err == nil {
-				// If restart check succeeded, try to apply config class (only once)
-				c.applyConfigOnce.Do(func() {
-					if applyErr := c.applyConfigClassToCluster(); applyErr != nil {
-						c.logger.Error("failed to apply config class", zap.Error(applyErr))
-					}
-				})
-			}
+
+			// Apply config class to cluster only once when the agent starts
+			c.applyConfigOnce.Do(func() {
+				if applyErr := c.applyConfigClassToCluster(); applyErr != nil {
+					c.logger.Error("failed to apply config class", zap.Error(applyErr))
+				}
+			})
 			errCh <- err
 		}
 	}


### PR DESCRIPTION
## Description
- Integrate token-based PUT API for applying config groups to hosts and clusters while restart status API calls or when new host/cluster introduced
- Use sync.Once to ensure config class application executes only once per agent lifecycle
