### PR TITLE
Fix: Avoid agent crash on Windows and Darwin due to missing telemetry factory

### DIFF
--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -614,8 +614,7 @@ func (c *HostAgent) callRestartStatusAPI() error {
 			return err
 		}
 
-		c.logger.Info("restart agent due to config change")
-		return err
+		return ErrRestartAgent
 	}
 
 	return err

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -614,7 +614,8 @@ func (c *HostAgent) callRestartStatusAPI() error {
 			return err
 		}
 
-		return ErrRestartAgent
+		c.logger.Info("restart agent due to config change")
+		return err
 	}
 
 	return err
@@ -818,6 +819,10 @@ func (c *HostAgent) ReportServices(
 	errCh chan<- error,
 	stopCh <-chan struct{},
 ) error {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		c.logger.Info("service discovery reporting is not supported on this platform; skipping")
+		return nil
+	}
 
 	if !c.AgentFeatures.ServiceReporting {
 		c.logger.Info("service discovery reporting is disabled; skipping")

--- a/pkg/agent/hostagent_darwin.go
+++ b/pkg/agent/hostagent_darwin.go
@@ -51,6 +51,7 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 )
 
 // GetFactories get otel factories for HostAgent
@@ -60,6 +61,7 @@ func (c *HostAgent) getFactories() (otelcol.Factories, error) {
 		Receivers:  make(map[component.Type]receiver.Factory),
 		Exporters:  make(map[component.Type]exporter.Factory),
 		Processors: make(map[component.Type]processor.Factory),
+		Telemetry:  otelconftelemetry.NewFactory(),
 	}
 
 	factories.Extensions = make(map[component.Type]extension.Factory)

--- a/pkg/agent/hostagent_windows.go
+++ b/pkg/agent/hostagent_windows.go
@@ -50,6 +50,7 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 )
 
 // GetFactories get otel factories for HostAgent
@@ -59,6 +60,7 @@ func (c *HostAgent) getFactories() (otelcol.Factories, error) {
 		Receivers:  make(map[component.Type]receiver.Factory),
 		Exporters:  make(map[component.Type]exporter.Factory),
 		Processors: make(map[component.Type]processor.Factory),
+		Telemetry:  otelconftelemetry.NewFactory(),
 	}
 
 	factories.Extensions = make(map[component.Type]extension.Factory)


### PR DESCRIPTION
## Description
- Fix agent crashing issue for windows and darwin machine by adding Telemetry factory
- Skip service discovery for the windows and darwin machine
- Error handling for redundant return