### PR TITLE
AGE-417 : add interface + struct to support otel native integration for postgresql

### DIFF
--- a/pkg/agent/db-config_test.yaml
+++ b/pkg/agent/db-config_test.yaml
@@ -1,7 +1,7 @@
 postgresql:
   endpoint: "example.com:5432"
   database: "mydb"
-  user: "myuser"
+  username: "myuser"
   password: "mypassword"
 
 mongodb:

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -321,7 +321,7 @@ func (c *HostAgent) updateConfigWithRestrictions(config map[string]interface{}) 
 	return config, nil
 }
 
-func (c *HostAgent) updateConfig(config map[string]interface{}, cnf integrationConfiguration) (map[string]interface{}, error) {
+func (c *HostAgent) updateConfig(config map[string]interface{}, cnf integrationConfiguration, integrationType IntegrationType) (map[string]interface{}, error) {
 
 	if c.isIPPortFormat(cnf.Endpoint) {
 		return config, nil
@@ -340,28 +340,46 @@ func (c *HostAgent) updateConfig(config map[string]interface{}, cnf integrationC
 		return map[string]interface{}{}, err
 	}
 
-	// Add the temporary map to the existing "receiver" key
-	receiverData, ok := config["receivers"].(map[string]interface{})
+	// Unmarshal the YAML data into the IntegrationConfig struct to easily access the integration configuration
+	var integrationConfig IntegrationConfig
+	err = yaml.Unmarshal(updatedYamlData, &integrationConfig)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+
+	var integration Integration
+	receiverConfig, ok := config["receivers"].(map[string]interface{})
 	if !ok {
 		return map[string]interface{}{}, ErrKeyNotFound
 	}
-
-	for key, value := range tempMap {
-		mapValue, mapValueOk := value.(map[interface{}]interface{})
-		if mapValueOk {
-			oldValue, oldValueOk := receiverData[key]
-			if oldValueOk {
-				oldMapValue, oldMapValueOk := oldValue.(map[string]interface{})
-				if oldMapValueOk {
-					for k, v := range mapValue {
-						strKey, keyOk := k.(string)
-						if keyOk {
-							oldMapValue[strKey] = v
-						} else {
-							c.logger.Info("invalid key type", zap.Any("key type", k))
+	switch integrationType {
+	case PostgreSQL:
+		if integrationConfig.Postgresql != nil {
+			integration = integrationConfig.Postgresql
+			err := integration.UpdateReceiverConfig(receiverConfig)
+			if err != nil {
+				return map[string]interface{}{}, fmt.Errorf("failed to update receiver config for postgresql : %w", err)
+			}
+		}
+	default:
+		// Add the temporary map to the existing "receiver" key
+		for key, value := range tempMap {
+			mapValue, mapValueOk := value.(map[interface{}]interface{})
+			if mapValueOk {
+				oldValue, oldValueOk := receiverConfig[key]
+				if oldValueOk {
+					oldMapValue, oldMapValueOk := oldValue.(map[string]interface{})
+					if oldMapValueOk {
+						for k, v := range mapValue {
+							strKey, keyOk := k.(string)
+							if keyOk {
+								oldMapValue[strKey] = v
+							} else {
+								c.logger.Info("invalid key type", zap.Any("key type", k))
+							}
 						}
+						receiverConfig[key] = oldMapValue
 					}
-					receiverData[key] = oldMapValue
 				}
 			}
 		}
@@ -457,7 +475,7 @@ func (c *HostAgent) updateConfigFile(configType string) error {
 
 	for integrationType, integrationConfig := range integrationConfigs {
 		if c.checkIntConfigValidity(integrationType, integrationConfig) {
-			apiYAMLConfig, err = c.updateConfig(apiYAMLConfig, integrationConfig)
+			apiYAMLConfig, err = c.updateConfig(apiYAMLConfig, integrationConfig, integrationType)
 			if err != nil {
 				return err
 			}
@@ -707,6 +725,7 @@ func (c *HostAgent) ListenForConfigChanges(errCh chan<- error,
 	// First fetch the config
 	_, err := c.getOtelConfig()
 	if err != nil {
+		c.logger.Error("failed to get otel config while listening for config changes", zap.Error(err))
 		errCh <- err
 	} else {
 		errCh <- nil

--- a/pkg/agent/hostagent_test.go
+++ b/pkg/agent/hostagent_test.go
@@ -38,7 +38,7 @@ func TestUpdatepgdbConfig(t *testing.T) {
 	zapCore := zapcore.NewNopCore()
 	agent, _ := NewHostAgent(HostConfig{}, zapCore)
 	// Call the updatepgdbConfig function
-	updatedConfig, err := agent.updateConfig(initialConfig, pgdbConfig)
+	updatedConfig, err := agent.updateConfig(initialConfig, pgdbConfig, PostgreSQL)
 	assert.NoError(t, err)
 
 	// Assert that the updated config contains the expected values
@@ -74,7 +74,7 @@ func TestUpdateMongodbConfig(t *testing.T) {
 	zapCore := zapcore.NewNopCore()
 	agent, _ := NewHostAgent(HostConfig{}, zapCore)
 
-	updatedConfig, err := agent.updateConfig(initialConfig, mongodbConfig)
+	updatedConfig, err := agent.updateConfig(initialConfig, mongodbConfig, MongoDB)
 	assert.NoError(t, err)
 
 	// Assert that the updated config contains the expected values
@@ -111,7 +111,7 @@ func TestUpdateMysqlConfig(t *testing.T) {
 	zapCore := zapcore.NewNopCore()
 	agent, _ := NewHostAgent(cfg, zapCore)
 	// Call the updateMysqlConfig function
-	updatedConfig, err := agent.updateConfig(initialConfig, mysqlConfig)
+	updatedConfig, err := agent.updateConfig(initialConfig, mysqlConfig, MySQL)
 	assert.NoError(t, err)
 
 	// Assert that the updated config contains the expected values
@@ -146,7 +146,7 @@ func TestUpdateRedisConfig(t *testing.T) {
 	zapCore := zapcore.NewNopCore()
 	agent, _ := NewHostAgent(cfg, zapCore)
 	// Call the updateRedisConfig function
-	updatedConfig, err := agent.updateConfig(initialConfig, redisConfig)
+	updatedConfig, err := agent.updateConfig(initialConfig, redisConfig, Redis)
 	assert.NoError(t, err)
 
 	// Assert that the updated config contains the expected values

--- a/pkg/agent/integration.go
+++ b/pkg/agent/integration.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"fmt"
+)
+
+// ========== Postgresql Receiver Config Updates ==========
+func (postgresql *Postgresql) UpdateReceiverConfig(receiverConfig map[string]interface{}) error {
+	postresqlReceiverConfig, ok := receiverConfig["postgresql"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("postgresql receiver config not found in receiverConfig")
+	}
+	// username (required)
+	if postgresql.Username == "" {
+		return fmt.Errorf("username is required field in postgresql integration configuration")
+	}
+	postresqlReceiverConfig["username"] = postgresql.Username
+	// password (required)
+	if postgresql.Password == "" {
+		return fmt.Errorf("password is required field in postgresql integration configuration")
+	}
+	postresqlReceiverConfig["password"] = postgresql.Password
+	// endpoint
+	if postgresql.Endpoint != "" {
+		postresqlReceiverConfig["endpoint"] = postgresql.Endpoint
+	}
+	// databases
+	if len(postgresql.Databases) > 0 {
+		postresqlReceiverConfig["databases"] = postgresql.Databases
+	}
+	// exclude_databases
+	if len(postgresql.ExcludeDatabases) > 0 {
+		postresqlReceiverConfig["exclude_databases"] = postgresql.ExcludeDatabases
+	}
+	// collection_interval
+	if postgresql.CollectionInterval != "" {
+		postresqlReceiverConfig["collection_interval"] = postgresql.CollectionInterval
+	}
+	// transport
+	if postgresql.Transport != "" {
+		postresqlReceiverConfig["transport"] = postgresql.Transport
+	}
+	// tls
+	if postgresql.TLS != nil {
+		tls := map[string]interface{}{
+			"insecure":             postgresql.TLS.Insecure,
+			"insecure_skip_verify": postgresql.TLS.InsecureSkipVerify,
+		}
+		if !postgresql.TLS.InsecureSkipVerify {
+			if (postgresql.TLS.CertFile != "" && postgresql.TLS.KeyFile == "") || (postgresql.TLS.KeyFile != "" && postgresql.TLS.CertFile == "") {
+				return fmt.Errorf("both cert_file and key_file must be provided together in TLS configuration for postgresql integration")
+			} else if postgresql.TLS.CertFile != "" && postgresql.TLS.KeyFile != "" {
+				tls["cert_file"] = postgresql.TLS.CertFile
+				tls["key_file"] = postgresql.TLS.KeyFile
+			}
+			if postgresql.TLS.CaFile != "" {
+				tls["ca_file"] = postgresql.TLS.CaFile
+			}
+		}
+		postresqlReceiverConfig["tls"] = tls
+	}
+	// events
+	if postgresql.Events != nil {
+		postresqlReceiverConfig["events"] = map[string]interface{}{
+			"db.server.query_sample": map[string]interface{}{
+				"enabled": postgresql.Events.DbServerQuerySample.Enabled,
+			},
+			"db.server.top_query": map[string]interface{}{
+				"enabled": postgresql.Events.DbServerTopQuery.Enabled,
+			},
+		}
+	}
+	// query_sample_collection
+	if postgresql.QuerySampleCollection != nil {
+		if postgresql.QuerySampleCollection.MaxRowsPerQuery <= 0 {
+			postgresql.QuerySampleCollection.MaxRowsPerQuery = 1000
+		}
+		postresqlReceiverConfig["query_sample_collection"] = map[string]interface{}{
+			"max_rows_per_query": postgresql.QuerySampleCollection.MaxRowsPerQuery,
+		}
+	}
+	// top_query_collection
+	if postgresql.TopQueryCollection != nil {
+		if postgresql.TopQueryCollection.TopNQuery <= 0 {
+			postgresql.TopQueryCollection.TopNQuery = 1000
+		}
+		if postgresql.TopQueryCollection.MaxRowsPerQuery <= 0 {
+			postgresql.TopQueryCollection.MaxRowsPerQuery = 1000
+		}
+		if postgresql.TopQueryCollection.MaxExplainEachInterval <= 0 {
+			postgresql.TopQueryCollection.MaxExplainEachInterval = 1000
+		}
+		if postgresql.TopQueryCollection.QueryPlanCacheSize <= 0 {
+			postgresql.TopQueryCollection.QueryPlanCacheSize = 1000
+		}
+		if postgresql.TopQueryCollection.QueryPlanCacheTTL == "" {
+			postgresql.TopQueryCollection.QueryPlanCacheTTL = "1h"
+		}
+		postresqlReceiverConfig["top_query_collection"] = map[string]interface{}{
+			"top_n_query":               postgresql.TopQueryCollection.TopNQuery,
+			"max_rows_per_query":        postgresql.TopQueryCollection.MaxRowsPerQuery,
+			"max_explain_each_interval": postgresql.TopQueryCollection.MaxExplainEachInterval,
+			"query_plan_cache_size":     postgresql.TopQueryCollection.QueryPlanCacheSize,
+			"query_plan_cache_ttl":      postgresql.TopQueryCollection.QueryPlanCacheTTL,
+		}
+	}
+	// connection_pool
+	if postgresql.ConectionPool != nil {
+		if postgresql.ConectionPool.MaxIdleTime == "" {
+			postgresql.ConectionPool.MaxIdleTime = "10m"
+		}
+		if postgresql.ConectionPool.MaxLifetime == "" {
+			postgresql.ConectionPool.MaxLifetime = "10m"
+		}
+		if postgresql.ConectionPool.MaxIdle <= 0 {
+			postgresql.ConectionPool.MaxIdle = 10
+		}
+		if postgresql.ConectionPool.MaxOpen <= 0 {
+			postgresql.ConectionPool.MaxOpen = 10
+		}
+		postresqlReceiverConfig["connection_pool"] = map[string]interface{}{
+			"max_idle_time": postgresql.ConectionPool.MaxIdleTime,
+			"max_lifetime":  postgresql.ConectionPool.MaxLifetime,
+			"max_idle":      postgresql.ConectionPool.MaxIdle,
+			"max_open":      postgresql.ConectionPool.MaxOpen,
+		}
+	}
+	return nil
+}

--- a/pkg/agent/integration_types.go
+++ b/pkg/agent/integration_types.go
@@ -1,0 +1,57 @@
+package agent
+
+// ========== Integration Configuration ==========
+type IntegrationConfig struct {
+	Postgresql *Postgresql `json:"postgresql,omitempty" yaml:"postgresql,omitempty"`
+}
+
+// ========= Integration Interface ==========
+type Integration interface {
+	UpdateReceiverConfig(receiverConfig map[string]interface{}) error
+}
+
+// ========== Postgresql Configuration ==========
+type Postgresql struct {
+	Username              string                           `json:"username,omitempty" yaml:"username,omitempty"`
+	Password              string                           `json:"password,omitempty" yaml:"password,omitempty"`
+	Endpoint              string                           `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Databases             []string                         `json:"databases,omitempty" yaml:"databases,omitempty"`
+	ExcludeDatabases      []string                         `json:"exclude_databases,omitempty" yaml:"exclude_databases,omitempty"`
+	CollectionInterval    string                           `json:"collection_interval,omitempty" yaml:"collection_interval,omitempty"`
+	Transport             string                           `json:"transport,omitempty" yaml:"transport,omitempty"`
+	TLS                   *PostgresqlTLS                   `json:"tls,omitempty" yaml:"tls,omitempty"`
+	Events                *PostgresqlEvents                `json:"events,omitempty" yaml:"events,omitempty"`
+	QuerySampleCollection *PostgresqlQuerySampleCollection `json:"query_sample_collection,omitempty" yaml:"query_sample_collection,omitempty"`
+	TopQueryCollection    *PostgresqlTopQueryCollection    `json:"top_query_collection,omitempty" yaml:"top_query_collection,omitempty"`
+	ConectionPool         *PostgresqlConnectionPool        `json:"connection_pool,omitempty" yaml:"connection_pool,omitempty"`
+}
+type PostgresqlTLS struct {
+	Insecure           bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty"`
+	CertFile           string `json:"cert_file,omitempty" yaml:"cert_file,omitempty"`
+	KeyFile            string `json:"key_file,omitempty" yaml:"key_file,omitempty"`
+	CaFile             string `json:"ca_file,omitempty" yaml:"ca_file,omitempty"`
+}
+type PostgresqlEvents struct {
+	DbServerQuerySample PostgresqlEnabled `json:"db.server.query_sample,omitempty" yaml:"db.server.query_sample,omitempty"`
+	DbServerTopQuery    PostgresqlEnabled `json:"db.server.top_query,omitempty" yaml:"db.server.top_query,omitempty"`
+}
+type PostgresqlEnabled struct {
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+type PostgresqlQuerySampleCollection struct {
+	MaxRowsPerQuery int `json:"max_rows_per_query,omitempty" yaml:"max_rows_per_query,omitempty"`
+}
+type PostgresqlTopQueryCollection struct {
+	TopNQuery              int    `json:"top_n_query,omitempty" yaml:"top_n_query,omitempty"`
+	MaxRowsPerQuery        int    `json:"max_rows_per_query,omitempty" yaml:"max_rows_per_query,omitempty"`
+	MaxExplainEachInterval int    `json:"max_explain_each_interval,omitempty" yaml:"max_explain_each_interval,omitempty"`
+	QueryPlanCacheSize     int    `json:"query_plan_cache_size,omitempty" yaml:"query_plan_cache_size,omitempty"`
+	QueryPlanCacheTTL      string `json:"query_plan_cache_ttl,omitempty" yaml:"query_plan_cache_ttl,omitempty"`
+}
+type PostgresqlConnectionPool struct {
+	MaxIdleTime string `json:"max_idle_time,omitempty" yaml:"max_idle_time,omitempty"`
+	MaxLifetime string `json:"max_lifetime,omitempty" yaml:"max_lifetime,omitempty"`
+	MaxIdle     int    `json:"max_idle,omitempty" yaml:"max_idle,omitempty"`
+	MaxOpen     int    `json:"max_open,omitempty" yaml:"max_open,omitempty"`
+}


### PR DESCRIPTION
## 🎯 AGE-417: Add interface + struct support for OTEL native PostgreSQL integration

This PR introduces an interface-based abstraction to support OTEL native integration for PostgreSQL, enabling custom receiver configuration handling while preserving default behavior for other integrations.

The goal is to allow gradual rollout of structured integrations without breaking or refactoring existing map-based integrations.

### Summary

- This PR introduces structured support for OTEL native PostgreSQL integration while preserving existing behavior for other integrations.

### Changes
- Added Integration interface with UpdateReceiverConfig contract.
- Introduced typed IntegrationConfig and Postgresql configuration structs.
- Implemented PostgreSQL-specific receiver mutation logic, including:
    - Required field validation (username, password)
    - TLS validation
    - Default handling for query and connection pool settings
- Refactored updateConfig to accept IntegrationType and apply integration-aware logic.
- Preserved existing generic merge behavior for non-structured integrations.
- Updated unit tests to reflect new method signature.
### Impact
- No breaking changes.
- Existing MongoDB, MySQL, and Redis and all other integrations continue to work as before.
- Establishes foundation for gradual migration to structured, OTEL-native integrations.