### PR TITLE
Individual systemd instrumentation commands

### DIFF
--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/k0kubun/pp"
+	"github.com/middleware-labs/java-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -633,6 +635,210 @@ func main() {
 				Action: func(c *cli.Context) error {
 					fmt.Println("Middleware Agent Version", agentVersion)
 					return nil
+				},
+			},
+			{
+				Name: "list",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "systemd",
+						Usage: "List all systemd units",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					if c.Bool("systemd") {
+						units, err := otelinject.ListUnits()
+						if err != nil {
+							return fmt.Errorf("failed to list systemd units: %w", err)
+						}
+						pp.Println(units)
+						return nil
+					}
+
+					return fmt.Errorf("please specify a flag (e.g. --systemd)")
+				},
+			},
+			{
+				Name:  "instrument",
+				Usage: "instruments services",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "node", // Child command
+						Usage: "Instrument Node.js systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Instrumenting node-js services")
+							nodeinj, err := otelinject.NewNodeSystemdInjector()
+							nodeinj.Instrument()
+							pp.Println(nodeinj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
+					{
+						Name:  "systemd",
+						Usage: "Instrument a specific systemd unit",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "language",
+								Usage:    "Language of the service (python, java, node)",
+								Required: true,
+							},
+						},
+						Action: func(c *cli.Context) error {
+							pp.Println("In action")
+
+							// 1. Get the unit name from the positional arguments, not a flag
+							unitName := c.Args().First()
+							if unitName == "" {
+								return fmt.Errorf("you must provide a systemd unit name as an argument")
+							}
+
+							// 2. Since your flag is marked Required: true, urfave/cli will
+							// error out before this point if it's missing, but we still grab it.
+							lang := c.String("language")
+
+							var language otelinject.Language
+							switch lang {
+							case "python":
+								language = otelinject.LanguagePython
+							case "java":
+								language = otelinject.LanguageJava
+							case "node":
+								language = otelinject.LanguageNode
+							default:
+								return fmt.Errorf("unsupported language %q: must be one of python, java, node", lang)
+							}
+
+							fmt.Printf("Instrumenting systemd unit: %s (language: %s)\n", unitName, language)
+							pp.Println("------------------Instrumenting:::>>> ", unitName, " ", language)
+
+							err := otelinject.InstrumentUnit(unitName, language)
+							if err != nil {
+								return fmt.Errorf("failed to instrument systemd unit %s: %w", unitName, err)
+							}
+
+							return nil
+						},
+					},
+					{
+						Name:  "java", // Child command
+						Usage: "Instrument Java systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Instrumenting java services")
+							javainj, err := otelinject.NewJavaSystemdInjector()
+							javainj.Instrument()
+							pp.Println(javainj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
+					{
+						Name:  "python", // Child command
+						Usage: "Instrument python systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Instrumenting python services")
+							pythonInj, err := otelinject.NewPythonSystemdInjector()
+							pythonInj.Instrument()
+							pp.Println(pythonInj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
+				},
+			},
+			{
+				Name:  "uninstrument",
+				Usage: "uninstruments services",
+				// Flags: []cli.Flag{
+				// 	&cli.StringFlag{
+				// 		Name:  "systemd",
+				// 		Usage: "Uninstrument a specific systemd unit by name (e.g. book-service-java.service)",
+				// 	},
+				// },
+				// Action: func(c *cli.Context) error {
+				// 	pp.Println("Uninstrumenting")
+				// 	if c.IsSet("systemd") {
+				// 		pp.Println("Uninstrumenting systemd unit")
+				// 		unitName := c.String("systemd")
+				// 		if unitName == "" {
+				// 			return fmt.Errorf("--systemd flag requires a unit name")
+				// 		}
+				// 		fmt.Printf("Instrumenting systemd unit: %s\n", unitName)
+				// 		// TODO: call your systemd-specific instrumentation logic here
+				// 		err := otelinject.UninstrumentUnit(unitName)
+				// 		if err != nil {
+				// 			return fmt.Errorf("failed to create systemd injector for %s: %w", unitName, err)
+				// 		}
+				// 		return nil
+				// 	}
+				// 	return nil
+				// },
+				Subcommands: []*cli.Command{
+					{
+						Name:  "systemd",
+						Usage: "uninstruments systemd unit",
+						Action: func(c *cli.Context) error {
+							pp.Println("In uninstrument sub action.")
+							unitName := c.Args().First()
+							if unitName == "" {
+								return fmt.Errorf("you must provide a systemd unit name to uninstrumment")
+							}
+
+							err := otelinject.UninstrumentUnit(unitName)
+							if err != nil {
+								return fmt.Errorf("failed to uninstrument systemd unit %s: %v", unitName, err)
+							}
+							return nil
+						},
+					},
+					{
+						Name:  "node", // Child command
+						Usage: "uninstrument Node.js systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Instrumenting node-js services")
+							nodeinj, err := otelinject.NewNodeSystemdInjector()
+							nodeinj.Uninstrument()
+							pp.Println(nodeinj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
+					{
+						Name:  "java", // Child command
+						Usage: "uninstrument Java systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Uninstrumenting java services")
+							javainj, err := otelinject.NewJavaSystemdInjector()
+							javainj.Uninstrument()
+							pp.Println(javainj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
+					{
+						Name:  "python", // Child command
+						Usage: "uninstrument python systemd services",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Uninstrumenting python services")
+							pythoninj, err := otelinject.NewPythonSystemdInjector()
+							pythoninj.Uninstrument()
+							pp.Println(pythoninj.Status)
+							if err != nil {
+								pp.Println("Oh no!!! ", err.Error())
+							}
+							return nil
+						},
+					},
 				},
 			},
 		},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -309,7 +309,7 @@ func getFlags(execPath string, cfg *agent.HostConfig) []cli.Flag {
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        "agent-features.service-reporting",
 			Usage:       "Enable or disable service discovery reporting.",
-			EnvVars:     []string{"MW_REPORT_SERVICES"},
+			EnvVars:     []string{"MW_AGENT_FEATURES_REPORT_SERVICES", "MW_REPORT_SERVICES"},
 			Destination: &cfg.AgentFeatures.ServiceReporting,
 			DefaultText: "true",
 			Value:       true,

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -728,6 +728,9 @@ func main() {
 					unitName := c.Args().First()
 
 					if unitName != "" {
+						if _, err := newSystemdInjector(lang); err != nil {
+							return err
+						}
 						fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
 						if err := otelinject.InstrumentUnit(unitName, otelinject.Language(lang)); err != nil {
 							return fmt.Errorf("failed to instrument %s: %w", unitName, err)

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -386,29 +386,8 @@ func detectInfraPlatform() agent.InfraPlatform {
 	return agent.InfraPlatformInstance
 }
 
-// newSystemdInjector returns the OtelInjector for the given language string.
-// Adding a new language is a one-liner here.
-func newSystemdInjector(lang string) (otelinject.OtelInjector, error) {
-	constructors := map[string]func() (otelinject.OtelInjector, error){
-		"java": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewJavaSystemdInjector()
-		},
-		"python": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewPythonSystemdInjector()
-		},
-		"node": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewNodeSystemdInjector()
-		},
-	}
-	fn, ok := constructors[lang]
-	if !ok {
-		return nil, fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
-	}
-	return fn()
-}
-
 // resolveLanguage maps a language string to its typed otelinject.Language constant,
-// returning an error for unsupported values. This avoids raw string casts at call sites.
+// returning an error for unsupported values. Single source of truth for language validation.
 func resolveLanguage(lang string) (otelinject.Language, error) {
 	languages := map[string]otelinject.Language{
 		"java":   otelinject.LanguageJava,
@@ -420,6 +399,27 @@ func resolveLanguage(lang string) (otelinject.Language, error) {
 		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
 	}
 	return l, nil
+}
+
+// newSystemdInjector returns the OtelInjector for the given language string.
+// Delegates language validation to resolveLanguage — adding a new language
+// requires updating resolveLanguage and this constructor map.
+func newSystemdInjector(lang string) (otelinject.OtelInjector, error) {
+	if _, err := resolveLanguage(lang); err != nil {
+		return nil, err
+	}
+	constructors := map[string]func() (otelinject.OtelInjector, error){
+		"java": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewJavaSystemdInjector()
+		},
+		"python": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewPythonSystemdInjector()
+		},
+		"node": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewNodeSystemdInjector()
+		},
+	}
+	return constructors[lang]()
 }
 
 func main() {
@@ -788,6 +788,9 @@ func main() {
 					unitName := c.Args().First()
 					lang := c.String("language")
 
+					// Uninstrumenting a specific unit is language-agnostic — the drop-in
+					// is removed regardless of runtime. --language is only needed for bulk
+					// operations. Reject both together to keep the interface unambiguous.
 					if unitName != "" && lang != "" {
 						return fmt.Errorf("provide either a unit name or --language, not both")
 					}

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"text/tabwriter"
 
-	"github.com/k0kubun/pp"
 	"github.com/middleware-labs/java-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
@@ -638,208 +638,196 @@ func main() {
 				},
 			},
 			{
-				Name: "list",
+				Name:  "list",
+				Usage: "List instrumented services",
 				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:  "systemd",
-						Usage: "List all systemd units",
+					&cli.StringFlag{
+						Name:     "type",
+						Usage:    "Deployment type to list (systemd)",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:  "language",
+						Usage: "Filter by language (java, python, node). Lists all languages if omitted.",
 					},
 				},
 				Action: func(c *cli.Context) error {
-					if c.Bool("systemd") {
-						units, err := otelinject.ListUnits()
-						pp.Println(units)
-						if err != nil {
-							return fmt.Errorf("failed to list systemd units: %w", err)
-						}
-						return nil
+					if c.String("type") != "systemd" {
+						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
+					}
+					services, err := otelinject.ListServices()
+					if err != nil {
+						return fmt.Errorf("failed to list systemd services: %w", err)
 					}
 
-					return fmt.Errorf("please specify a flag (e.g. --systemd)")
+					langFilter := c.String("language")
+					w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+					fmt.Fprintln(w, "UNIT\tNAME\tLANGUAGE\tPID\tOWNER\tSTATUS\tAGENT TYPE\tINSTRUMENTED")
+					fmt.Fprintln(w, "----\t----\t--------\t---\t-----\t------\t----------\t------------")
+					for _, s := range services {
+						if langFilter != "" && s.Language != langFilter {
+							continue
+						}
+						instrumented := "no"
+						if s.Instrumented {
+							instrumented = "yes"
+						}
+						agentType := s.AgentType
+						if agentType == "" {
+							agentType = "-"
+						}
+						fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+							s.SystemdUnit, s.Name, s.Language, s.PID, s.Owner, s.Status, agentType, instrumented,
+						)
+					}
+					return w.Flush()
 				},
 			},
 			{
 				Name:  "instrument",
-				Usage: "instruments services",
-				Subcommands: []*cli.Command{
-					{
-						Name:  "node", // Child command
-						Usage: "Instrument Node.js systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Instrumenting node-js services")
-							nodeinj, err := otelinject.NewNodeSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create node injector: %w", err)
-							}
-							if err := nodeinj.Instrument(); err != nil {
-								return fmt.Errorf("failed to instrument node services: %w", err)
-							}
-							fmt.Println(nodeinj.Status)
-							return nil
-						},
+				Usage: "Instrument services",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "type",
+						Usage:    "Deployment type (systemd)",
+						Required: true,
 					},
-					{
-						Name:  "systemd",
-						Usage: "Instrument a specific systemd unit",
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "language",
-								Usage:    "Language of the service (python, java, node)",
-								Required: true,
-							},
-						},
-						Action: func(c *cli.Context) error {
-
-							// 1. Get the unit name from the positional arguments, not a flag
-							unitName := c.Args().First()
-							if unitName == "" {
-								return fmt.Errorf("you must provide a systemd unit name as an argument")
-							}
-
-							// 2. Since your flag is marked Required: true, urfave/cli will
-							// error out before this point if it's missing, but we still grab it.
-							lang := c.String("language")
-
-							var language otelinject.Language
-							switch lang {
-							case "python":
-								language = otelinject.LanguagePython
-							case "java":
-								language = otelinject.LanguageJava
-							case "node":
-								language = otelinject.LanguageNode
-							default:
-								return fmt.Errorf("unsupported language %q: must be one of python, java, node", lang)
-							}
-
-							fmt.Printf("Instrumenting systemd unit: %s (language: %s)\n", unitName, language)
-
-							err := otelinject.InstrumentUnit(unitName, language)
-							if err != nil {
-								return fmt.Errorf("failed to instrument systemd unit %s: %w", unitName, err)
-							}
-
-							return nil
-						},
+					&cli.StringFlag{
+						Name:     "language",
+						Usage:    "Language of the service (java, python, node)",
+						Required: true,
 					},
-					{
-						Name:  "java", // Child command
-						Usage: "Instrument Java systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Instrumenting java services")
-							javainj, err := otelinject.NewJavaSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create java injector: %w", err)
-							}
-							if err := javainj.Instrument(); err != nil {
-								return fmt.Errorf("failed to instrument java services: %w", err)
-							}
-							fmt.Println(javainj.Status)
-							return nil
-						},
-					},
-					{
-						Name:  "python", // Child command
-						Usage: "Instrument python systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Instrumenting python services")
-							pythonInj, err := otelinject.NewPythonSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create python injector: %w", err)
-							}
-							if err := pythonInj.Instrument(); err != nil {
-								return fmt.Errorf("failed to instrument python services: %w", err)
-							}
-							fmt.Println(pythonInj.Status)
-							return nil
-						},
-					},
-					{
-						Name:  "node",
-						Usage: "Instrument node systemd service",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Instrumenting node services")
-							nodeInj, err := otelinject.NewNodeSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create node injector: %w", err)
-							}
-							if err := nodeInj.Instrument(); err != nil {
-								return fmt.Errorf("failed to instrument node services: %w", err)
-							}
-							fmt.Println(nodeInj.Status)
-							return nil
-						},
-					},
+				},
+				Action: func(c *cli.Context) error {
+					if c.String("type") != "systemd" {
+						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
+					}
+
+					lang := c.String("language")
+					unitName := c.Args().First()
+
+					if unitName != "" {
+						var language otelinject.Language
+						switch lang {
+						case "python":
+							language = otelinject.LanguagePython
+						case "java":
+							language = otelinject.LanguageJava
+						case "node":
+							language = otelinject.LanguageNode
+						default:
+							return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+						}
+						fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
+						if err := otelinject.InstrumentUnit(unitName, language); err != nil {
+							return fmt.Errorf("failed to instrument %s: %w", unitName, err)
+						}
+						return nil
+					}
+
+					switch lang {
+					case "java":
+						inj, err := otelinject.NewJavaSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create java injector: %w", err)
+						}
+						if err := inj.Instrument(); err != nil {
+							return fmt.Errorf("failed to instrument java services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					case "python":
+						inj, err := otelinject.NewPythonSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create python injector: %w", err)
+						}
+						if err := inj.Instrument(); err != nil {
+							return fmt.Errorf("failed to instrument python services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					case "node":
+						inj, err := otelinject.NewNodeSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create node injector: %w", err)
+						}
+						if err := inj.Instrument(); err != nil {
+							return fmt.Errorf("failed to instrument node services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					default:
+						return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+					}
+					return nil
 				},
 			},
 			{
 				Name:  "uninstrument",
-				Usage: "uninstruments services",
-				Subcommands: []*cli.Command{
-					{
-						Name:  "systemd",
-						Usage: "uninstruments systemd unit",
-						Action: func(c *cli.Context) error {
-							unitName := c.Args().First()
-							if unitName == "" {
-								return fmt.Errorf("you must provide a systemd unit name to uninstrumment")
-							}
+				Usage: "Uninstrument services",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "type",
+						Usage:    "Deployment type (systemd)",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:  "language",
+						Usage: "Language of the service (java, python, node). Required when no unit name is given.",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					if c.String("type") != "systemd" {
+						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
+					}
 
-							err := otelinject.UninstrumentUnit(unitName)
-							if err != nil {
-								return fmt.Errorf("failed to uninstrument systemd unit %s: %v", unitName, err)
-							}
-							return nil
-						},
-					},
-					{
-						Name:  "node", // Child command
-						Usage: "uninstrument Node.js systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Uninstrumenting node-js services")
-							nodeinj, err := otelinject.NewNodeSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create node injector: %w", err)
-							}
-							if err := nodeinj.Uninstrument(); err != nil {
-								return fmt.Errorf("failed to uninstrument node services: %w", err)
-							}
-							fmt.Println(nodeinj.Status)
-							return nil
-						},
-					},
-					{
-						Name:  "java", // Child command
-						Usage: "uninstrument Java systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Uninstrumenting java services")
-							javainj, err := otelinject.NewJavaSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create java injector: %w", err)
-							}
-							if err := javainj.Uninstrument(); err != nil {
-								return fmt.Errorf("failed to uninstrument java services: %w", err)
-							}
-							fmt.Println(javainj.Status)
-							return nil
-						},
-					},
-					{
-						Name:  "python", // Child command
-						Usage: "uninstrument python systemd services",
-						Action: func(c *cli.Context) error {
-							fmt.Println("Uninstrumenting python services")
-							pythoninj, err := otelinject.NewPythonSystemdInjector()
-							if err != nil {
-								return fmt.Errorf("failed to create python injector: %w", err)
-							}
-							if err := pythoninj.Uninstrument(); err != nil {
-								return fmt.Errorf("failed to uninstrument python services: %w", err)
-							}
-							fmt.Println(pythoninj.Status)
-							return nil
-						},
-					},
+					unitName := c.Args().First()
+					lang := c.String("language")
+
+					if unitName != "" && lang != "" {
+						return fmt.Errorf("provide either a unit name or --language, not both")
+					}
+
+					if unitName != "" {
+						if err := otelinject.UninstrumentUnit(unitName); err != nil {
+							return fmt.Errorf("failed to uninstrument %s: %w", unitName, err)
+						}
+						return nil
+					}
+
+					if lang == "" {
+						return fmt.Errorf("provide a unit name or --language")
+					}
+
+					switch lang {
+					case "java":
+						inj, err := otelinject.NewJavaSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create java injector: %w", err)
+						}
+						if err := inj.Uninstrument(); err != nil {
+							return fmt.Errorf("failed to uninstrument java services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					case "python":
+						inj, err := otelinject.NewPythonSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create python injector: %w", err)
+						}
+						if err := inj.Uninstrument(); err != nil {
+							return fmt.Errorf("failed to uninstrument python services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					case "node":
+						inj, err := otelinject.NewNodeSystemdInjector()
+						if err != nil {
+							return fmt.Errorf("failed to create node injector: %w", err)
+						}
+						if err := inj.Uninstrument(); err != nil {
+							return fmt.Errorf("failed to uninstrument node services: %w", err)
+						}
+						fmt.Println(inj.Status)
+					default:
+						return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+					}
+					return nil
 				},
 			},
 		},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -407,6 +407,21 @@ func newSystemdInjector(lang string) (otelinject.OtelInjector, error) {
 	return fn()
 }
 
+// resolveLanguage maps a language string to its typed otelinject.Language constant,
+// returning an error for unsupported values. This avoids raw string casts at call sites.
+func resolveLanguage(lang string) (otelinject.Language, error) {
+	languages := map[string]otelinject.Language{
+		"java":   otelinject.LanguageJava,
+		"python": otelinject.LanguagePython,
+		"node":   otelinject.LanguageNode,
+	}
+	l, ok := languages[lang]
+	if !ok {
+		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+	}
+	return l, nil
+}
+
 func main() {
 	zapEncoderCfg := zapcore.EncoderConfig{
 		MessageKey: "message",
@@ -728,11 +743,12 @@ func main() {
 					unitName := c.Args().First()
 
 					if unitName != "" {
-						if _, err := newSystemdInjector(lang); err != nil {
+						language, err := resolveLanguage(lang)
+						if err != nil {
 							return err
 						}
 						fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
-						if err := otelinject.InstrumentUnit(unitName, otelinject.Language(lang)); err != nil {
+						if err := otelinject.InstrumentUnit(unitName, language); err != nil {
 							return fmt.Errorf("failed to instrument %s: %w", unitName, err)
 						}
 						fmt.Printf("Successfully instrumented %s\n", unitName)

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -655,7 +655,7 @@ func main() {
 					if c.String("type") != "systemd" {
 						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
 					}
-					services, err := otelinject.ListServices()
+					services, err := otelinject.ListSystemdServices()
 					if err != nil {
 						return fmt.Errorf("failed to list systemd services: %w", err)
 					}

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -648,10 +648,10 @@ func main() {
 				Action: func(c *cli.Context) error {
 					if c.Bool("systemd") {
 						units, err := otelinject.ListUnits()
+						pp.Println(units)
 						if err != nil {
 							return fmt.Errorf("failed to list systemd units: %w", err)
 						}
-						pp.Println(units)
 						return nil
 					}
 
@@ -689,7 +689,6 @@ func main() {
 							},
 						},
 						Action: func(c *cli.Context) error {
-							pp.Println("In action")
 
 							// 1. Get the unit name from the positional arguments, not a flag
 							unitName := c.Args().First()
@@ -714,7 +713,6 @@ func main() {
 							}
 
 							fmt.Printf("Instrumenting systemd unit: %s (language: %s)\n", unitName, language)
-							pp.Println("------------------Instrumenting:::>>> ", unitName, " ", language)
 
 							err := otelinject.InstrumentUnit(unitName, language)
 							if err != nil {
@@ -782,7 +780,6 @@ func main() {
 						Name:  "systemd",
 						Usage: "uninstruments systemd unit",
 						Action: func(c *cli.Context) error {
-							pp.Println("In uninstrument sub action.")
 							unitName := c.Args().First()
 							if unitName == "" {
 								return fmt.Errorf("you must provide a systemd unit name to uninstrumment")

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -309,7 +309,7 @@ func getFlags(execPath string, cfg *agent.HostConfig) []cli.Flag {
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        "agent-features.service-reporting",
 			Usage:       "Enable or disable service discovery reporting.",
-			EnvVars:     []string{"MW_AGENT_FEATURES_REPORT_SERVICES", "MW_REPORT_SERVICES"},
+			EnvVars:     []string{"MW_AGENT_FEATURES_REPORT_SERVICES"},
 			Destination: &cfg.AgentFeatures.ServiceReporting,
 			DefaultText: "true",
 			Value:       true,

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -668,11 +668,13 @@ func main() {
 						Action: func(c *cli.Context) error {
 							fmt.Println("Instrumenting node-js services")
 							nodeinj, err := otelinject.NewNodeSystemdInjector()
-							nodeinj.Instrument()
-							pp.Println(nodeinj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create node injector: %w", err)
 							}
+							if err := nodeinj.Instrument(); err != nil {
+								return fmt.Errorf("failed to instrument node services: %w", err)
+							}
+							fmt.Println(nodeinj.Status)
 							return nil
 						},
 					},
@@ -728,11 +730,13 @@ func main() {
 						Action: func(c *cli.Context) error {
 							fmt.Println("Instrumenting java services")
 							javainj, err := otelinject.NewJavaSystemdInjector()
-							javainj.Instrument()
-							pp.Println(javainj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create java injector: %w", err)
 							}
+							if err := javainj.Instrument(); err != nil {
+								return fmt.Errorf("failed to instrument java services: %w", err)
+							}
+							fmt.Println(javainj.Status)
 							return nil
 						},
 					},
@@ -742,11 +746,29 @@ func main() {
 						Action: func(c *cli.Context) error {
 							fmt.Println("Instrumenting python services")
 							pythonInj, err := otelinject.NewPythonSystemdInjector()
-							pythonInj.Instrument()
-							pp.Println(pythonInj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create python injector: %w", err)
 							}
+							if err := pythonInj.Instrument(); err != nil {
+								return fmt.Errorf("failed to instrument python services: %w", err)
+							}
+							fmt.Println(pythonInj.Status)
+							return nil
+						},
+					},
+					{
+						Name:  "node",
+						Usage: "Instrument node systemd service",
+						Action: func(c *cli.Context) error {
+							fmt.Println("Instrumenting node services")
+							nodeInj, err := otelinject.NewNodeSystemdInjector()
+							if err != nil {
+								return fmt.Errorf("failed to create node injector: %w", err)
+							}
+							if err := nodeInj.Instrument(); err != nil {
+								return fmt.Errorf("failed to instrument node services: %w", err)
+							}
+							fmt.Println(nodeInj.Status)
 							return nil
 						},
 					},
@@ -755,30 +777,6 @@ func main() {
 			{
 				Name:  "uninstrument",
 				Usage: "uninstruments services",
-				// Flags: []cli.Flag{
-				// 	&cli.StringFlag{
-				// 		Name:  "systemd",
-				// 		Usage: "Uninstrument a specific systemd unit by name (e.g. book-service-java.service)",
-				// 	},
-				// },
-				// Action: func(c *cli.Context) error {
-				// 	pp.Println("Uninstrumenting")
-				// 	if c.IsSet("systemd") {
-				// 		pp.Println("Uninstrumenting systemd unit")
-				// 		unitName := c.String("systemd")
-				// 		if unitName == "" {
-				// 			return fmt.Errorf("--systemd flag requires a unit name")
-				// 		}
-				// 		fmt.Printf("Instrumenting systemd unit: %s\n", unitName)
-				// 		// TODO: call your systemd-specific instrumentation logic here
-				// 		err := otelinject.UninstrumentUnit(unitName)
-				// 		if err != nil {
-				// 			return fmt.Errorf("failed to create systemd injector for %s: %w", unitName, err)
-				// 		}
-				// 		return nil
-				// 	}
-				// 	return nil
-				// },
 				Subcommands: []*cli.Command{
 					{
 						Name:  "systemd",
@@ -801,13 +799,15 @@ func main() {
 						Name:  "node", // Child command
 						Usage: "uninstrument Node.js systemd services",
 						Action: func(c *cli.Context) error {
-							fmt.Println("Instrumenting node-js services")
+							fmt.Println("Uninstrumenting node-js services")
 							nodeinj, err := otelinject.NewNodeSystemdInjector()
-							nodeinj.Uninstrument()
-							pp.Println(nodeinj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create node injector: %w", err)
 							}
+							if err := nodeinj.Uninstrument(); err != nil {
+								return fmt.Errorf("failed to uninstrument node services: %w", err)
+							}
+							fmt.Println(nodeinj.Status)
 							return nil
 						},
 					},
@@ -817,11 +817,13 @@ func main() {
 						Action: func(c *cli.Context) error {
 							fmt.Println("Uninstrumenting java services")
 							javainj, err := otelinject.NewJavaSystemdInjector()
-							javainj.Uninstrument()
-							pp.Println(javainj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create java injector: %w", err)
 							}
+							if err := javainj.Uninstrument(); err != nil {
+								return fmt.Errorf("failed to uninstrument java services: %w", err)
+							}
+							fmt.Println(javainj.Status)
 							return nil
 						},
 					},
@@ -831,11 +833,13 @@ func main() {
 						Action: func(c *cli.Context) error {
 							fmt.Println("Uninstrumenting python services")
 							pythoninj, err := otelinject.NewPythonSystemdInjector()
-							pythoninj.Uninstrument()
-							pp.Println(pythoninj.Status)
 							if err != nil {
-								pp.Println("Oh no!!! ", err.Error())
+								return fmt.Errorf("failed to create python injector: %w", err)
 							}
+							if err := pythoninj.Uninstrument(); err != nil {
+								return fmt.Errorf("failed to uninstrument python services: %w", err)
+							}
+							fmt.Println(pythoninj.Status)
 							return nil
 						},
 					},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -386,6 +386,27 @@ func detectInfraPlatform() agent.InfraPlatform {
 	return agent.InfraPlatformInstance
 }
 
+// newSystemdInjector returns the OtelInjector for the given language string.
+// Adding a new language is a one-liner here.
+func newSystemdInjector(lang string) (otelinject.OtelInjector, error) {
+	constructors := map[string]func() (otelinject.OtelInjector, error){
+		"java": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewJavaSystemdInjector()
+		},
+		"python": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewPythonSystemdInjector()
+		},
+		"node": func() (otelinject.OtelInjector, error) {
+			return otelinject.NewNodeSystemdInjector()
+		},
+	}
+	fn, ok := constructors[lang]
+	if !ok {
+		return nil, fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+	}
+	return fn()
+}
+
 func main() {
 	zapEncoderCfg := zapcore.EncoderConfig{
 		MessageKey: "message",
@@ -707,55 +728,22 @@ func main() {
 					unitName := c.Args().First()
 
 					if unitName != "" {
-						var language otelinject.Language
-						switch lang {
-						case "python":
-							language = otelinject.LanguagePython
-						case "java":
-							language = otelinject.LanguageJava
-						case "node":
-							language = otelinject.LanguageNode
-						default:
-							return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
-						}
 						fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
-						if err := otelinject.InstrumentUnit(unitName, language); err != nil {
+						if err := otelinject.InstrumentUnit(unitName, otelinject.Language(lang)); err != nil {
 							return fmt.Errorf("failed to instrument %s: %w", unitName, err)
 						}
+						fmt.Printf("Successfully instrumented %s\n", unitName)
 						return nil
 					}
 
-					switch lang {
-					case "java":
-						inj, err := otelinject.NewJavaSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create java injector: %w", err)
-						}
-						if err := inj.Instrument(); err != nil {
-							return fmt.Errorf("failed to instrument java services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					case "python":
-						inj, err := otelinject.NewPythonSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create python injector: %w", err)
-						}
-						if err := inj.Instrument(); err != nil {
-							return fmt.Errorf("failed to instrument python services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					case "node":
-						inj, err := otelinject.NewNodeSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create node injector: %w", err)
-						}
-						if err := inj.Instrument(); err != nil {
-							return fmt.Errorf("failed to instrument node services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					default:
-						return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+					inj, err := newSystemdInjector(lang)
+					if err != nil {
+						return err
 					}
+					if err := inj.Instrument(); err != nil {
+						return fmt.Errorf("failed to instrument %s services: %w", lang, err)
+					}
+					fmt.Printf("Successfully instrumented all %s services\n", lang)
 					return nil
 				},
 			},
@@ -789,6 +777,7 @@ func main() {
 						if err := otelinject.UninstrumentUnit(unitName); err != nil {
 							return fmt.Errorf("failed to uninstrument %s: %w", unitName, err)
 						}
+						fmt.Printf("Successfully uninstrumented %s\n", unitName)
 						return nil
 					}
 
@@ -796,37 +785,14 @@ func main() {
 						return fmt.Errorf("provide a unit name or --language")
 					}
 
-					switch lang {
-					case "java":
-						inj, err := otelinject.NewJavaSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create java injector: %w", err)
-						}
-						if err := inj.Uninstrument(); err != nil {
-							return fmt.Errorf("failed to uninstrument java services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					case "python":
-						inj, err := otelinject.NewPythonSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create python injector: %w", err)
-						}
-						if err := inj.Uninstrument(); err != nil {
-							return fmt.Errorf("failed to uninstrument python services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					case "node":
-						inj, err := otelinject.NewNodeSystemdInjector()
-						if err != nil {
-							return fmt.Errorf("failed to create node injector: %w", err)
-						}
-						if err := inj.Uninstrument(); err != nil {
-							return fmt.Errorf("failed to uninstrument node services: %w", err)
-						}
-						fmt.Println(inj.Status)
-					default:
-						return fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+					inj, err := newSystemdInjector(lang)
+					if err != nil {
+						return err
 					}
+					if err := inj.Uninstrument(); err != nil {
+						return fmt.Errorf("failed to uninstrument %s services: %w", lang, err)
+					}
+					fmt.Printf("Successfully uninstrumented all %s services\n", lang)
 					return nil
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zooke
 
 replace go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.139.0
 
+//replace github.com/middleware-labs/java-injector v1.1.999 => ../mw-injector
+
 require (
 	github.com/prometheus/common v0.67.2
 	github.com/stretchr/testify v1.11.1
@@ -120,7 +122,8 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.0.4
+	github.com/k0kubun/pp v3.0.1+incompatible
+	github.com/middleware-labs/java-injector v1.1.998
 	github.com/middleware-labs/synthetics-agent v1.0.59
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0
@@ -309,7 +312,6 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/k0kubun/pp v3.0.1+incompatible // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 
 require (
 	github.com/k0kubun/pp v3.0.1+incompatible
-	github.com/middleware-labs/java-injector v1.1.998
+	github.com/middleware-labs/java-injector v1.1.0
 	github.com/middleware-labs/synthetics-agent v1.0.59
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.1.2
+	github.com/middleware-labs/java-injector v1.1.3
 	github.com/middleware-labs/synthetics-agent v1.0.59
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zooke
 
 replace go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.139.0
 
-//replace github.com/middleware-labs/java-injector v1.1.999 => ../mw-injector
-
 require (
 	github.com/prometheus/common v0.67.2
 	github.com/stretchr/testify v1.11.1
@@ -122,8 +120,7 @@ require (
 )
 
 require (
-	github.com/k0kubun/pp v3.0.1+incompatible
-	github.com/middleware-labs/java-injector v1.1.0
+	github.com/middleware-labs/java-injector v1.1.1
 	github.com/middleware-labs/synthetics-agent v1.0.59
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0
@@ -312,6 +309,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/k0kubun/pp v3.0.1+incompatible // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zooke
 
 replace go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.139.0
 
+// replace github.com/middleware-labs/java-injector v1.1.1 => ../mw-injector
+
 require (
 	github.com/prometheus/common v0.67.2
 	github.com/stretchr/testify v1.11.1
@@ -120,7 +122,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.1.1
+	github.com/middleware-labs/java-injector v1.1.2
 	github.com/middleware-labs/synthetics-agent v1.0.59
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.1.2 h1:jIhkVmG+zaLWsnnsfcIw57bh+7E407mpL9e9XlHySsg=
-github.com/middleware-labs/java-injector v1.1.2/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.1.3 h1:/z1UPdxBsQln06v7ytUq7Ot4QTw0G+oRUjyyrNb/8b8=
+github.com/middleware-labs/java-injector v1.1.3/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.1.0 h1:2UBDl6nViaTYV7T9cQn4jpd9Do9zxZ0CgxBvhDrWDGs=
-github.com/middleware-labs/java-injector v1.1.0/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.1.1 h1:fjWxoPUfaZ9eVhZn1qYHk6BbUQfy3ElOmEgB/pgzOU0=
+github.com/middleware-labs/java-injector v1.1.1/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.0.4 h1:i+asSaAa+i9VruYofGpG6woRf+T3rOb5EmMaLONRYqM=
-github.com/middleware-labs/java-injector v1.0.4/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.1.998 h1:5KI8kKRlYzxkIuVIUa0CSGWhmpX7omr+oWHzsPs0YbY=
+github.com/middleware-labs/java-injector v1.1.998/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.1.1 h1:fjWxoPUfaZ9eVhZn1qYHk6BbUQfy3ElOmEgB/pgzOU0=
-github.com/middleware-labs/java-injector v1.1.1/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.1.2 h1:jIhkVmG+zaLWsnnsfcIw57bh+7E407mpL9e9XlHySsg=
+github.com/middleware-labs/java-injector v1.1.2/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.1.998 h1:5KI8kKRlYzxkIuVIUa0CSGWhmpX7omr+oWHzsPs0YbY=
-github.com/middleware-labs/java-injector v1.1.998/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.1.0 h1:2UBDl6nViaTYV7T9cQn4jpd9Do9zxZ0CgxBvhDrWDGs=
+github.com/middleware-labs/java-injector v1.1.0/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/middleware-labs/java-injector/pkg/discovery"
+	"github.com/middleware-labs/java-injector/pkg/otelinject"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
@@ -896,7 +896,7 @@ func (c *HostAgent) ReportAgentStatusAPI() error {
 	}()
 	hostname := getHostname()
 	apikey := c.APIKey
-	err := discovery.ReportStatus(hostname, apikey, c.APIURLForConfigCheck, c.Version, c.InfraPlatform.String())
+	err := otelinject.ReportStatus(hostname, apikey, c.APIURLForConfigCheck, c.Version, c.InfraPlatform.String())
 	if err != nil {
 		zap.Error(err)
 		return fmt.Errorf("%w: %v", ErrReportApiFailure, err)


### PR DESCRIPTION
## Add Individual Systemd Instrumentation CLI Commands

Adds granular CLI commands for instrumenting and uninstrumenting systemd services by language and unit name, replacing the need to operate on all services at once.

### Changes

- **`mw-agent list --systemd`** — List all systemd units.
- **`mw-agent instrument <language>`** — Instrument all systemd services for a given language (`node`, `java`, `python`).
- **`mw-agent instrument systemd --language=<lang> <unit>`** — Instrument a specific systemd unit by name.
- **`mw-agent uninstrument systemd <unit>`** — Uninstrument a specific systemd unit.
- **`mw-agent uninstrument <language>`** — Uninstrument all systemd services for a given language.
- Migrated `ReportStatus` call from `discovery` to `otelinject` package.
- Bumped `java-injector` dependency from `v1.0.4` → `v1.1.0`.
- Added `github.com/k0kubun/pp` for debug printing.

