### PR TITLE
Add OBI instrumentation support, unified service discovery, and expanded language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 otelstruct.go
 build
 otel-config.yaml
+.vscode
+.cursor

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -410,10 +410,13 @@ func resolveLanguage(lang string) (otelinject.Language, error) {
 		"nodejs": otelinject.LanguageNode,
 		"go":     otelinject.LanguageGo,
 		"golang": otelinject.LanguageGo,
+		"rust":   otelinject.LanguageRust,
+		"php":    otelinject.LanguagePHP,
+		"ruby":   otelinject.LanguageRuby,
 	}
 	l, ok := languages[lang]
 	if !ok {
-		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node/nodejs, go/golang", lang)
+		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node/nodejs, go/golang, rust, php, ruby", lang)
 	}
 	return l, nil
 }
@@ -438,17 +441,28 @@ func newSystemdInjector(lang string, logger *slog.Logger) (otelinject.OtelInject
 			return otelinject.NewNodeSystemdInjectorWithLogger(logger)
 		},
 	}
-	return constructors[lang]()
+	ctor, ok := constructors[lang]
+	if !ok {
+		return nil, fmt.Errorf("language %q does not support systemd instrumentation; use --type obi instead (only java, python, node support systemd)", lang)
+	}
+	return ctor()
 }
 
 // instrumentSystemd handles --type systemd instrumentation.
+// systemdLanguages is the set of languages that support systemd drop-in instrumentation.
+var systemdLanguages = map[otelinject.Language]bool{
+	otelinject.LanguageJava:   true,
+	otelinject.LanguagePython: true,
+	otelinject.LanguageNode:   true,
+}
+
 func instrumentSystemd(lang, unitName string, logger *zap.Logger) error {
 	language, err := resolveLanguage(lang)
 	if err != nil {
 		return err
 	}
-	if language == otelinject.LanguageGo {
-		return fmt.Errorf("Go does not support systemd instrumentation (statically linked); use --type obi instead")
+	if !systemdLanguages[language] {
+		return fmt.Errorf("language %q does not support systemd instrumentation; use --type obi instead (only java, python, node support systemd)", lang)
 	}
 
 	if unitName != "" {
@@ -517,8 +531,8 @@ func uninstrumentSystemd(lang, unitName string, logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	if language == otelinject.LanguageGo {
-		return fmt.Errorf("Go does not support systemd instrumentation (statically linked); use --type obi instead")
+	if !systemdLanguages[language] {
+		return fmt.Errorf("language %q does not support systemd instrumentation; use --type obi instead (only java, python, node support systemd)", lang)
 	}
 
 	inj, err := newSystemdInjector(lang, zapToSlog(logger))

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -427,21 +427,22 @@ func resolveLanguage(lang string) (otelinject.Language, error) {
 // slog logger is passed to the discovery pipeline for structured timing
 // logs; pass nil for the silent path.
 func newSystemdInjector(lang string, logger *slog.Logger) (otelinject.OtelInjector, error) {
-	if _, err := resolveLanguage(lang); err != nil {
+	canonical, err := resolveLanguage(lang)
+	if err != nil {
 		return nil, err
 	}
-	constructors := map[string]func() (otelinject.OtelInjector, error){
-		"java": func() (otelinject.OtelInjector, error) {
+	constructors := map[otelinject.Language]func() (otelinject.OtelInjector, error){
+		otelinject.LanguageJava: func() (otelinject.OtelInjector, error) {
 			return otelinject.NewJavaSystemdInjectorWithLogger(logger)
 		},
-		"python": func() (otelinject.OtelInjector, error) {
+		otelinject.LanguagePython: func() (otelinject.OtelInjector, error) {
 			return otelinject.NewPythonSystemdInjectorWithLogger(logger)
 		},
-		"node": func() (otelinject.OtelInjector, error) {
+		otelinject.LanguageNode: func() (otelinject.OtelInjector, error) {
 			return otelinject.NewNodeSystemdInjectorWithLogger(logger)
 		},
 	}
-	ctor, ok := constructors[lang]
+	ctor, ok := constructors[canonical]
 	if !ok {
 		return nil, fmt.Errorf("language %q does not support systemd instrumentation; use --type obi instead (only java, python, node support systemd)", lang)
 	}
@@ -561,14 +562,13 @@ func uninstrumentOBI(identifier string, logger *zap.Logger) error {
 	return nil
 }
 
-var languageAliases = map[string]string{
-	"nodejs": "node",
-	"golang": "go",
-}
-
 func listServices(language string, showAll, quiet bool, logger *zap.Logger) error {
-	if mapped, ok := languageAliases[strings.ToLower(language)]; ok {
-		language = mapped
+	if language != "" {
+		canonical, err := resolveLanguage(language)
+		if err != nil {
+			return err
+		}
+		language = string(canonical)
 	}
 	entries, err := otelinject.DiscoverServices(otelinject.DiscoverServicesOpts{
 		Language: language,

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"text/tabwriter"
 
@@ -22,8 +24,20 @@ import (
 	"github.com/urfave/cli/v2/altsrc"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
 )
+
+// zapToSlog bridges a zap logger to an slog.Logger so packages that accept
+// *slog.Logger (like pkg/discovery in mw-injector) can share mw-agent's
+// logging configuration. Passing nil returns nil, which downstream code
+// treats as "no logging."
+func zapToSlog(z *zap.Logger) *slog.Logger {
+	if z == nil {
+		return nil
+	}
+	return slog.New(zapslog.NewHandler(z.Core()))
+}
 
 var agentVersion = "0.0.1"
 
@@ -393,33 +407,202 @@ func resolveLanguage(lang string) (otelinject.Language, error) {
 		"java":   otelinject.LanguageJava,
 		"python": otelinject.LanguagePython,
 		"node":   otelinject.LanguageNode,
+		"nodejs": otelinject.LanguageNode,
 	}
 	l, ok := languages[lang]
 	if !ok {
-		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node", lang)
+		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node/nodejs", lang)
 	}
 	return l, nil
 }
 
 // newSystemdInjector returns the OtelInjector for the given language string.
 // Delegates language validation to resolveLanguage — adding a new language
-// requires updating resolveLanguage and this constructor map.
-func newSystemdInjector(lang string) (otelinject.OtelInjector, error) {
+// requires updating resolveLanguage and this constructor map. The optional
+// slog logger is passed to the discovery pipeline for structured timing
+// logs; pass nil for the silent path.
+func newSystemdInjector(lang string, logger *slog.Logger) (otelinject.OtelInjector, error) {
 	if _, err := resolveLanguage(lang); err != nil {
 		return nil, err
 	}
 	constructors := map[string]func() (otelinject.OtelInjector, error){
 		"java": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewJavaSystemdInjector()
+			return otelinject.NewJavaSystemdInjectorWithLogger(logger)
 		},
 		"python": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewPythonSystemdInjector()
+			return otelinject.NewPythonSystemdInjectorWithLogger(logger)
 		},
 		"node": func() (otelinject.OtelInjector, error) {
-			return otelinject.NewNodeSystemdInjector()
+			return otelinject.NewNodeSystemdInjectorWithLogger(logger)
 		},
 	}
 	return constructors[lang]()
+}
+
+// instrumentSystemd handles --type systemd instrumentation.
+func instrumentSystemd(lang, unitName string, logger *zap.Logger) error {
+	if unitName != "" {
+		language, err := resolveLanguage(lang)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
+		if err := otelinject.InstrumentUnit(unitName, language); err != nil {
+			return fmt.Errorf("failed to instrument %s: %w", unitName, err)
+		}
+		fmt.Printf("Successfully instrumented %s\n", unitName)
+		return nil
+	}
+
+	inj, err := newSystemdInjector(lang, zapToSlog(logger))
+	if err != nil {
+		return err
+	}
+	if err := inj.Instrument(); err != nil {
+		return fmt.Errorf("failed to instrument %s services: %w", lang, err)
+	}
+	fmt.Printf("Successfully instrumented all %s services\n", lang)
+	return nil
+}
+
+// instrumentOBI handles --type obi instrumentation.
+func instrumentOBI(lang, serviceName string, logger *zap.Logger) error {
+	language, err := resolveLanguage(lang)
+	if err != nil {
+		return err
+	}
+
+	if serviceName != "" {
+		fmt.Printf("Instrumenting %s via OBI (language: %s)\n", serviceName, lang)
+		if err := otelinject.InstrumentOBI(serviceName, language, zapToSlog(logger)); err != nil {
+			return fmt.Errorf("failed to instrument %s via OBI: %w", serviceName, err)
+		}
+		fmt.Printf("Successfully instrumented %s via OBI\n", serviceName)
+		return nil
+	}
+
+	fmt.Printf("Instrumenting all %s services via OBI\n", lang)
+	if err := otelinject.InstrumentOBIBulk(language, zapToSlog(logger)); err != nil {
+		return fmt.Errorf("failed to instrument %s services via OBI: %w", lang, err)
+	}
+	fmt.Printf("Successfully instrumented all %s services via OBI\n", lang)
+	return nil
+}
+
+// uninstrumentSystemd handles --type systemd uninstrumentation.
+func uninstrumentSystemd(lang, unitName string, logger *zap.Logger) error {
+	if unitName != "" && lang != "" {
+		return fmt.Errorf("provide either a unit name or --language, not both")
+	}
+
+	if unitName != "" {
+		if err := otelinject.UninstrumentUnit(unitName); err != nil {
+			return fmt.Errorf("failed to uninstrument %s: %w", unitName, err)
+		}
+		fmt.Printf("Successfully uninstrumented %s\n", unitName)
+		return nil
+	}
+
+	if lang == "" {
+		return fmt.Errorf("provide a unit name or --language")
+	}
+
+	inj, err := newSystemdInjector(lang, zapToSlog(logger))
+	if err != nil {
+		return err
+	}
+	if err := inj.Uninstrument(); err != nil {
+		return fmt.Errorf("failed to uninstrument %s services: %w", lang, err)
+	}
+	fmt.Printf("Successfully uninstrumented all %s services\n", lang)
+	return nil
+}
+
+// uninstrumentOBI handles --type obi uninstrumentation.
+// identifier can be a service name or fingerprint.
+func uninstrumentOBI(identifier string, logger *zap.Logger) error {
+	if identifier == "" {
+		return fmt.Errorf("service name or fingerprint is required for OBI uninstrumentation")
+	}
+
+	fmt.Printf("Uninstrumenting %s from OBI\n", identifier)
+	if err := otelinject.UninstrumentOBI(identifier, zapToSlog(logger)); err != nil {
+		return fmt.Errorf("failed to uninstrument %s from OBI: %w", identifier, err)
+	}
+	fmt.Printf("Successfully uninstrumented %s from OBI\n", identifier)
+	return nil
+}
+
+var languageAliases = map[string]string{
+	"nodejs": "node",
+}
+
+func listServices(language string, showAll, quiet bool, logger *zap.Logger) error {
+	if mapped, ok := languageAliases[strings.ToLower(language)]; ok {
+		language = mapped
+	}
+	entries, err := otelinject.DiscoverServices(otelinject.DiscoverServicesOpts{
+		Language: language,
+		Logger:   zapToSlog(logger),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to discover services: %w", err)
+	}
+
+	if quiet {
+		for _, e := range entries {
+			fmt.Println(e.Fingerprint)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	if showAll {
+		fmt.Fprintln(w, "SERVICE ID\tSERVICE NAME\tLANGUAGE\tTYPE\tPORTS\tPID\tOWNER\tSTATUS\tINSTRUMENTED")
+		for _, e := range entries {
+			via := formatInstrumented(e)
+			for _, inst := range e.Instances {
+				ports := formatPorts(inst.Ports)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
+					e.Fingerprint, e.ServiceName, e.Language, e.ServiceType,
+					ports, inst.PID, inst.Owner, inst.Status, via,
+				)
+			}
+		}
+	} else {
+		fmt.Fprintln(w, "SERVICE ID\tSERVICE NAME\tLANGUAGE\tTYPE\tPORTS\tINSTANCES\tINSTRUMENTED")
+		for _, e := range entries {
+			ports := formatPorts(e.Ports)
+			via := formatInstrumented(e)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+				e.Fingerprint, e.ServiceName, e.Language, e.ServiceType,
+				ports, len(e.Instances), via,
+			)
+		}
+	}
+	return w.Flush()
+}
+
+func formatPorts(ports []int) string {
+	if len(ports) == 0 {
+		return "-"
+	}
+	s := make([]string, len(ports))
+	for i, p := range ports {
+		s[i] = strconv.Itoa(p)
+	}
+	return strings.Join(s, ",")
+}
+
+func formatInstrumented(e otelinject.ServiceEntry) string {
+	if !e.Instrumented {
+		return "-"
+	}
+	if e.InstrumentedVia != "" {
+		return e.InstrumentedVia
+	}
+	return "yes"
 }
 
 func main() {
@@ -674,49 +857,57 @@ func main() {
 				},
 			},
 			{
-				Name:  "list",
-				Usage: "List instrumented services",
+				Name:  "ps",
+				Usage: "List discovered services",
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "type",
-						Usage:    "Deployment type to list (systemd)",
-						Required: true,
+					&cli.BoolFlag{
+						Name:    "all",
+						Aliases: []string{"a"},
+						Usage:   "Show individual instances instead of grouping by fingerprint",
 					},
 					&cli.StringFlag{
-						Name:  "language",
-						Usage: "Filter by language (java, python, node). Lists all languages if omitted.",
+						Name:    "language",
+						Aliases: []string{"l"},
+						Usage:   "Filter by language (java, python, node)",
+					},
+					&cli.BoolFlag{
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display service IDs",
 					},
 				},
 				Action: func(c *cli.Context) error {
-					if c.String("type") != "systemd" {
-						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
-					}
-					services, err := otelinject.ListSystemdServices()
-					if err != nil {
-						return fmt.Errorf("failed to list systemd services: %w", err)
-					}
-
-					langFilter := c.String("language")
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-					fmt.Fprintln(w, "UNIT\tNAME\tLANGUAGE\tPID\tOWNER\tSTATUS\tAGENT TYPE\tINSTRUMENTED")
-					fmt.Fprintln(w, "----\t----\t--------\t---\t-----\t------\t----------\t------------")
-					for _, s := range services {
-						if langFilter != "" && s.Language != langFilter {
-							continue
-						}
-						instrumented := "no"
-						if s.Instrumented {
-							instrumented = "yes"
-						}
-						agentType := s.AgentType
-						if agentType == "" {
-							agentType = "-"
-						}
-						fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
-							s.SystemdUnit, s.Name, s.Language, s.PID, s.Owner, s.Status, agentType, instrumented,
-						)
-					}
-					return w.Flush()
+					return listServices(c.String("language"), c.Bool("all"), c.Bool("quiet"), logger)
+				},
+			},
+			{
+				Name:  "services",
+				Usage: "Manage discovered services",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "List discovered services",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:    "language",
+								Aliases: []string{"l"},
+								Usage:   "Filter by language (java, python, node). Lists all languages if omitted.",
+							},
+							&cli.BoolFlag{
+								Name:    "all",
+								Aliases: []string{"a"},
+								Usage:   "Show individual instances instead of grouping by fingerprint.",
+							},
+							&cli.BoolFlag{
+								Name:    "quiet",
+								Aliases: []string{"q"},
+								Usage:   "Only display service IDs.",
+							},
+						},
+						Action: func(c *cli.Context) error {
+							return listServices(c.String("language"), c.Bool("all"), c.Bool("quiet"), logger)
+						},
+					},
 				},
 			},
 			{
@@ -725,7 +916,7 @@ func main() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "type",
-						Usage:    "Deployment type (systemd)",
+						Usage:    "Deployment type (systemd, obi)",
 						Required: true,
 					},
 					&cli.StringFlag{
@@ -735,35 +926,18 @@ func main() {
 					},
 				},
 				Action: func(c *cli.Context) error {
-					if c.String("type") != "systemd" {
-						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
-					}
-
+					deployType := c.String("type")
 					lang := c.String("language")
-					unitName := c.Args().First()
+					serviceName := c.Args().First()
 
-					if unitName != "" {
-						language, err := resolveLanguage(lang)
-						if err != nil {
-							return err
-						}
-						fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
-						if err := otelinject.InstrumentUnit(unitName, language); err != nil {
-							return fmt.Errorf("failed to instrument %s: %w", unitName, err)
-						}
-						fmt.Printf("Successfully instrumented %s\n", unitName)
-						return nil
+					switch deployType {
+					case "systemd":
+						return instrumentSystemd(lang, serviceName, logger)
+					case "obi":
+						return instrumentOBI(lang, serviceName, logger)
+					default:
+						return fmt.Errorf("unsupported type %q: must be systemd or obi", deployType)
 					}
-
-					inj, err := newSystemdInjector(lang)
-					if err != nil {
-						return err
-					}
-					if err := inj.Instrument(); err != nil {
-						return fmt.Errorf("failed to instrument %s services: %w", lang, err)
-					}
-					fmt.Printf("Successfully instrumented all %s services\n", lang)
-					return nil
 				},
 			},
 			{
@@ -772,50 +946,27 @@ func main() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "type",
-						Usage:    "Deployment type (systemd)",
+						Usage:    "Deployment type (systemd, obi)",
 						Required: true,
 					},
 					&cli.StringFlag{
 						Name:  "language",
-						Usage: "Language of the service (java, python, node). Required when no unit name is given.",
+						Usage: "Language of the service (java, python, node). Required for bulk operations.",
 					},
 				},
 				Action: func(c *cli.Context) error {
-					if c.String("type") != "systemd" {
-						return fmt.Errorf("unsupported type %q: only systemd is supported", c.String("type"))
-					}
-
-					unitName := c.Args().First()
+					deployType := c.String("type")
+					serviceName := c.Args().First()
 					lang := c.String("language")
 
-					// Uninstrumenting a specific unit is language-agnostic — the drop-in
-					// is removed regardless of runtime. --language is only needed for bulk
-					// operations. Reject both together to keep the interface unambiguous.
-					if unitName != "" && lang != "" {
-						return fmt.Errorf("provide either a unit name or --language, not both")
+					switch deployType {
+					case "systemd":
+						return uninstrumentSystemd(lang, serviceName, logger)
+					case "obi":
+						return uninstrumentOBI(serviceName, logger)
+					default:
+						return fmt.Errorf("unsupported type %q: must be systemd or obi", deployType)
 					}
-
-					if unitName != "" {
-						if err := otelinject.UninstrumentUnit(unitName); err != nil {
-							return fmt.Errorf("failed to uninstrument %s: %w", unitName, err)
-						}
-						fmt.Printf("Successfully uninstrumented %s\n", unitName)
-						return nil
-					}
-
-					if lang == "" {
-						return fmt.Errorf("provide a unit name or --language")
-					}
-
-					inj, err := newSystemdInjector(lang)
-					if err != nil {
-						return err
-					}
-					if err := inj.Uninstrument(); err != nil {
-						return fmt.Errorf("failed to uninstrument %s services: %w", lang, err)
-					}
-					fmt.Printf("Successfully uninstrumented all %s services\n", lang)
-					return nil
 				},
 			},
 		},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -408,10 +408,12 @@ func resolveLanguage(lang string) (otelinject.Language, error) {
 		"python": otelinject.LanguagePython,
 		"node":   otelinject.LanguageNode,
 		"nodejs": otelinject.LanguageNode,
+		"go":     otelinject.LanguageGo,
+		"golang": otelinject.LanguageGo,
 	}
 	l, ok := languages[lang]
 	if !ok {
-		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node/nodejs", lang)
+		return "", fmt.Errorf("unsupported language %q: must be one of java, python, node/nodejs, go/golang", lang)
 	}
 	return l, nil
 }
@@ -441,11 +443,15 @@ func newSystemdInjector(lang string, logger *slog.Logger) (otelinject.OtelInject
 
 // instrumentSystemd handles --type systemd instrumentation.
 func instrumentSystemd(lang, unitName string, logger *zap.Logger) error {
+	language, err := resolveLanguage(lang)
+	if err != nil {
+		return err
+	}
+	if language == otelinject.LanguageGo {
+		return fmt.Errorf("Go does not support systemd instrumentation (statically linked); use --type obi instead")
+	}
+
 	if unitName != "" {
-		language, err := resolveLanguage(lang)
-		if err != nil {
-			return err
-		}
 		fmt.Printf("Instrumenting systemd unit %s (language: %s)\n", unitName, lang)
 		if err := otelinject.InstrumentUnit(unitName, language); err != nil {
 			return fmt.Errorf("failed to instrument %s: %w", unitName, err)
@@ -507,6 +513,14 @@ func uninstrumentSystemd(lang, unitName string, logger *zap.Logger) error {
 		return fmt.Errorf("provide a unit name or --language")
 	}
 
+	language, err := resolveLanguage(lang)
+	if err != nil {
+		return err
+	}
+	if language == otelinject.LanguageGo {
+		return fmt.Errorf("Go does not support systemd instrumentation (statically linked); use --type obi instead")
+	}
+
 	inj, err := newSystemdInjector(lang, zapToSlog(logger))
 	if err != nil {
 		return err
@@ -535,6 +549,7 @@ func uninstrumentOBI(identifier string, logger *zap.Logger) error {
 
 var languageAliases = map[string]string{
 	"nodejs": "node",
+	"golang": "go",
 }
 
 func listServices(language string, showAll, quiet bool, logger *zap.Logger) error {
@@ -921,7 +936,7 @@ func main() {
 					},
 					&cli.StringFlag{
 						Name:     "language",
-						Usage:    "Language of the service (java, python, node)",
+						Usage:    "Language of the service (java, python, node, go)",
 						Required: true,
 					},
 				},
@@ -951,7 +966,7 @@ func main() {
 					},
 					&cli.StringFlag{
 						Name:  "language",
-						Usage: "Language of the service (java, python, node). Required for bulk operations.",
+						Usage: "Language of the service (java, python, node, go). Required for bulk operations.",
 					},
 				},
 				Action: func(c *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.2.0-test
+	github.com/middleware-labs/java-injector v1.2.0
 	github.com/middleware-labs/synthetics-agent v1.0.62
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zooke
 
 replace go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.139.0
 
-// replace github.com/middleware-labs/java-injector v1.1.1 => ../mw-injector
-
 require (
 	github.com/prometheus/common v0.67.2
 	github.com/stretchr/testify v1.11.1
@@ -122,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.1.3
+	github.com/middleware-labs/java-injector v1.2.0-test
 	github.com/middleware-labs/synthetics-agent v1.0.62
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0
@@ -134,6 +132,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.45.0
 	go.opentelemetry.io/collector/otelcol v0.139.0
 	go.opentelemetry.io/collector/service v0.139.0
+	go.uber.org/zap/exp v0.3.0
 )
 
 require (
@@ -527,7 +526,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.2.0-test h1:uhFwVSheUt1hhb/+iggITq/CCKwmMOJjUIWEINJkfSI=
-github.com/middleware-labs/java-injector v1.2.0-test/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
+github.com/middleware-labs/java-injector v1.2.0 h1:F41EWrOA5KD/1kGcUBDrH05fRfqaA4Zm3GMeh61zvJ4=
+github.com/middleware-labs/java-injector v1.2.0/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.1.3 h1:/z1UPdxBsQln06v7ytUq7Ot4QTw0G+oRUjyyrNb/8b8=
-github.com/middleware-labs/java-injector v1.1.3/go.mod h1:Tp3k/DCxHmAfvuGqV89NdejAjPYBTpOagxt0/ID2+wE=
+github.com/middleware-labs/java-injector v1.2.0-test h1:uhFwVSheUt1hhb/+iggITq/CCKwmMOJjUIWEINJkfSI=
+github.com/middleware-labs/java-injector v1.2.0-test/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -886,6 +888,17 @@ func (c *HostAgent) ReportServices(
 	}
 }
 
+// zapToSlog adapts a zap.Logger into a *slog.Logger so library packages that
+// accept the stdlib logger (e.g. mw-injector) can emit through the agent's
+// existing zap pipeline. Returns nil for a nil input (callers treat nil as
+// "no logging").
+func zapToSlog(z *zap.Logger) *slog.Logger {
+	if z == nil {
+		return nil
+	}
+	return slog.New(zapslog.NewHandler(z.Core()))
+}
+
 func (c *HostAgent) ReportAgentStatusAPI() error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -896,7 +909,7 @@ func (c *HostAgent) ReportAgentStatusAPI() error {
 	}()
 	hostname := getHostname()
 	apikey := c.APIKey
-	err := otelinject.ReportStatus(hostname, apikey, c.APIURLForConfigCheck, c.Version, c.InfraPlatform.String())
+	err := otelinject.ReportStatusWithLogger(hostname, apikey, c.APIURLForConfigCheck, c.Version, c.InfraPlatform.String(), zapToSlog(c.logger))
 	if err != nil {
 		zap.Error(err)
 		return fmt.Errorf("%w: %v", ErrReportApiFailure, err)


### PR DESCRIPTION
### **User description**
## Summary

  - Add OBI (eBPF-based) instrumentation as a new `--type obi` option alongside existing
  `--type systemd` for `instrument` and `uninstrument` commands
  - Replace the `list` subcommand with a unified `ps` command (and `services list`) that
  discovers all services across instrumentation types, with `--all`, `--language`, and
  `--quiet` flags
  - Expand language support to include Go, Rust, PHP, and Ruby (with aliases
  `nodejs`→`node`, `golang`→`go`); systemd instrumentation remains limited to
  Java/Python/Node with clear error messages directing users to OBI for other languages
  - Update `java-injector` dependency from v1.1.3 to v1.2.0 and promote
  `go.uber.org/zap/exp` to a direct dependency for zap→slog bridging
  - Add `zapToSlog` bridge so mw-injector's slog-based packages share the agent's zap
  logging pipeline

  ## Test plan

  - [ ] Verify `mw-host-agent instrument --type systemd --language java` still works for
  Java/Python/Node
  - [ ] Verify `mw-host-agent instrument --type obi --language go` instruments Go services
  via OBI
  - [ ] Verify `mw-host-agent instrument --type systemd --language go` returns a clear error
   directing to OBI
  - [ ] Verify `mw-host-agent ps` lists discovered services across all types
  - [ ] Verify `mw-host-agent ps --language node --all --quiet` flags work correctly
  - [ ] Verify `mw-host-agent uninstrument --type obi <service>` removes OBI instrumentation
  - [ ] Verify `mw-host-agent uninstrument --type systemd --language java` bulk
  uninstrumentation works
  - [ ] Verify `mw-host-agent services list` mirrors `ps` behavior


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Adds OBI (eBPF-based) instrumentation support via `--type obi` flag.

- Replaces `list` with a unified `ps` and `services list` command.

- Expands language support to Go, Rust, PHP, and Ruby.

- Integrates `zapToSlog` bridge for unified logging across packages.

- Updates `java-injector` dependency to v1.2.0 for enhanced functionality.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI (ps/instrument)"] -- "Unified Discovery" --> Discovery["pkg/discovery"]
  CLI -- "Type: systemd" --> SystemdInj["Systemd Injector"]
  CLI -- "Type: obi" --> OBIInj["OBI Injector"]
  SystemdInj -- "Java/Python/Node" --> Target["Services"]
  OBIInj -- "Go/Rust/PHP/Ruby/..." --> Target
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Expand CLI with OBI support and unified service discovery</code></dd></summary>
<hr>

cmd/host-agent/main.go

<ul><li>Implemented <code>instrumentOBI</code> and <code>uninstrumentOBI</code> to support eBPF-based <br>instrumentation.<br> <li> Added a unified <code>listServices</code> function used by new <code>ps</code> and <code>services list</code> <br>commands.<br> <li> Expanded <code>resolveLanguage</code> to support Go, Rust, PHP, and Ruby with <br>aliases.<br> <li> Added <code>zapToSlog</code> to bridge <code>zap</code> logging to <code>slog</code> for internal library <br>compatibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/291/files#diff-eb82aa5ee7274afbde953137c719decba139e0b2422f0565b40681f335cd5a4a">+287/-107</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hostagent.go</strong><dd><code>Integrate structured logging bridge in host agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/hostagent.go

<ul><li>Added <code>zapToSlog</code> utility to convert the agent's <code>zap.Logger</code> to <br><code>slog.Logger</code>.<br> <li> Updated <code>ReportAgentStatusAPI</code> to use <code>ReportStatusWithLogger</code>, passing <br>the bridged logger for better observability.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/291/files#diff-01bb9ad0061934f77631c55d7cb1f494d03732b6f31c8d848504518fd7f51912">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update dependencies and promote zap/exp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated <code>github.com/middleware-labs/java-injector</code> from v1.1.3 to <br>v1.2.0.<br> <li> Promoted <code>go.uber.org/zap/exp</code> to a direct dependency.<br> <li> Removed obsolete <code>replace</code> directive for <code>java-injector</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/291/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

