### PR TITLE
feat: add redis receiver in kube-agent

### DIFF
--- a/pkg/agent/kubeagent.go
+++ b/pkg/agent/kubeagent.go
@@ -43,6 +43,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
@@ -198,6 +199,7 @@ func (k *KubeAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 		mongodbreceiver.NewFactory(),
 		postgresqlreceiver.NewFactory(),
 		elasticsearchreceiver.NewFactory(),
+		redisreceiver.NewFactory(),
 		zookeeperreceiver.NewFactory(),
 	}
 

--- a/pkg/agent/kubeagent_test.go
+++ b/pkg/agent/kubeagent_test.go
@@ -36,7 +36,7 @@ func TestKubeAgentGetFactories(t *testing.T) {
 	assert.Len(t, factories.Extensions, 1)
 
 	// check if factories contains expected receivers
-	assert.Len(t, factories.Receivers, 21)
+	assert.Len(t, factories.Receivers, 22)
 	assertContainsComponent(t, factories.Receivers, "otlp")
 	assertContainsComponent(t, factories.Receivers, "fluentforward")
 	assertContainsComponent(t, factories.Receivers, "filelog")
@@ -55,6 +55,7 @@ func TestKubeAgentGetFactories(t *testing.T) {
 	assertContainsComponent(t, factories.Receivers, "mongodbatlas")
 	assertContainsComponent(t, factories.Receivers, "postgresql")
 	assertContainsComponent(t, factories.Receivers, "elasticsearch")
+	assertContainsComponent(t, factories.Receivers, "redis")
 	assertContainsComponent(t, factories.Receivers, "zookeeper")
 
 	// check if factories contain expected exporters


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Integrate Redis receiver into the KubeAgent.

- Register `redisreceiver` factory in the agent's factory list.

- Update unit tests to reflect the new receiver.

- Verify Redis receiver presence in test assertions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph KubeAgent
    A["kubeagent.go"] -- "Registers" --> B["redisreceiver"]
  end
  subgraph Tests
    C["kubeagent_test.go"] -- "Validates" --> B
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubeagent.go</strong><dd><code>Register Redis receiver factory in KubeAgent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/kubeagent.go

<ul><li>Added the <code>redisreceiver</code> package to the imports.<br> <li> Included <code>redisreceiver.NewFactory()</code> in the <code>receiverfactories</code> slice <br>within the <code>GetFactories</code> method.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/295/files#diff-5608a9eeeefcf95e4c068ecee730b00c7ad1db8303a7139c836036060c60eaab">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubeagent_test.go</strong><dd><code>Update unit tests for Redis receiver inclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/kubeagent_test.go

<ul><li>Updated the expected number of receivers from 21 to 22 in <br><code>TestKubeAgentGetFactories</code>.<br> <li> Added an assertion to verify that the <code>redis</code> receiver is present in the <br>factories.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/295/files#diff-056a8e25e9d35a7f6217fcb6a6fb162f75e9ee7ad32755dd82216279340a4155">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

