### PR TITLE
MongoDB Receiver: bson unmarshal issue for query metric slow_operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubel
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-20260203101750-23450dbe285c
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528060453-9bfe789c5994
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.0.0-20260512133141-3eb5d9cdf8ee
 

--- a/go.sum
+++ b/go.sum
@@ -682,8 +682,8 @@ github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kafkametrics
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:iaLOe9i/mQaQgCpwg9x2uJdLjRTARPkMFsr7p75bttA=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:4ad+C2vySX1P4Iy1q83GQqGuUSvoSVmC8rTpPqfs7kE=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:IGVGI0yoKsigON35IeUjdHYFhJMvzsh0e0hAQJ4gipU=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412 h1:BU8mUR6rPpcKlRgnv9Sp+GN1zHj8Hdjgqz6Q6iHS7QY=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412/go.mod h1:FLnKpVrHf2DoZfc5b0DhAA/GemkrikIyR/N7GZ6F/6o=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528060453-9bfe789c5994 h1:QIr/cQERrOgZ5D5l5WgiEEIEfQJ4Z4RpkMB6Uypd8AI=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528060453-9bfe789c5994/go.mod h1:FLnKpVrHf2DoZfc5b0DhAA/GemkrikIyR/N7GZ6F/6o=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:wbp2o56VoJclXr4PvCmWX951dcTqyQ5zDH/JQM+t020=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:/v4rvhGer4DSu6vqw84Sb13IW8isIqqPRqFMsVbld4E=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/nginxreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:YT26bllvJ88Cmis9v9UdNcfpbsUPZOXkhypXo8XDh7Y=


### PR DESCRIPTION
### **User description**
Due to conflict with **v1 v2 mongo** driver and **bson** unmarshall the slow operation are not getting collected


___

### **PR Type**
Bug fix


___

### **Description**
- Update `mongodbreceiver` dependency in `go.mod`.

- Fix BSON unmarshaling for `slow_operation` metrics.

- Resolve MongoDB driver version compatibility issues.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  node1["go.mod"] -- "Update mongodbreceiver" --> node2["Fix BSON unmarshaling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update mongodbreceiver dependency to fix BSON unmarshaling</code></dd></summary>
<hr>

go.mod

<ul><li>Updates the <code>replace</code> directive for the <code>mongodbreceiver</code> module.<br> <li> Points to a newer version to resolve BSON unmarshaling issues for <br><code>slow_operation</code> metrics.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/296/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

