### PR TITLE
impr: bump up mw-injector to v1.2.2

### DIFF
--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.2.2
+	github.com/middleware-labs/mw-injector v1.2.3
 	github.com/middleware-labs/synthetics-agent v1.0.63
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.2.1
+	github.com/middleware-labs/java-injector v1.2.2
 	github.com/middleware-labs/synthetics-agent v1.0.63
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.2.1 h1:KUHZN61IFIuP31Q8Fxh8xlsqyseyNOSVzqg7BbpmFhk=
-github.com/middleware-labs/java-injector v1.2.1/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
+github.com/middleware-labs/java-injector v1.2.2 h1:ZHThS1tlEK7nS2RB90qmabUtCV+ztJsJqUMDOByUxc4=
+github.com/middleware-labs/java-injector v1.2.2/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.2.2 h1:ZHThS1tlEK7nS2RB90qmabUtCV+ztJsJqUMDOByUxc4=
-github.com/middleware-labs/java-injector v1.2.2/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
+github.com/middleware-labs/mw-injector v1.2.3 h1:XOK0pj6WemZhGLvg1scc4HIlvkUtBVgVQcXVRqMXZUQ=
+github.com/middleware-labs/mw-injector v1.2.3/go.mod h1:/GBMrvr6uRbOWS9gtjm+5k6HZEfgFL6fZ9+Z3UdDhyM=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update java-injector dependency to v1.2.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OldVer["java-injector v1.2.1"] -- "bump to" --> NewVer["java-injector v1.2.2"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update java-injector dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated the <code>github.com/middleware-labs/java-injector</code> dependency from <br>version <code>v1.2.1</code> to <code>v1.2.2</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/297/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

