### PR TITLE
Fix/ec2 hostname

### DIFF
--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -304,11 +304,6 @@ func IsEC2Instance() bool {
 	return err == nil
 }
 
-// getEC2Hostname retrieves the internal hostname/FQDN from AWS EC2 metadata service
-func getEC2Hostname() (string, error) {
-	return getEC2Metadata("local-hostname")
-}
-
 func getHostname() string {
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -319,15 +314,6 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
-	// Get EC2 full hostname when running on EC2, otherwise use system hostname
-	if infraPlatform == InfraPlatformEC2 {
-		hostname, err := getEC2Hostname()
-		if err != nil {
-			// Fall back to system hostname if EC2 hostname retrieval fails
-			return getHostname()
-		}
-		return hostname
-	}
 	return getHostname()
 }
 

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go"
-	"github.com/k0kubun/pp"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 )
@@ -315,7 +314,6 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
-	pp.Println("HOSTNAME::::::>>>>>>", getHostname())
 	return getHostname()
 }
 

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go"
+	"github.com/k0kubun/pp"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 )
@@ -314,6 +315,7 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
+	pp.Println("HOSTNAME::::::>>>>>>", getHostname())
 	return getHostname()
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Standardize hostname retrieval using `os.Hostname()`.

- Remove EC2 IMDS `local-hostname` lookup logic.

- Align with OTel resource detection standards.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GHFP["GetHostnameForPlatform"] -- "removes EC2-specific logic" --> GH["getHostname"]
  GH -- "calls" --> OH["os.Hostname()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>definitions.go</strong><dd><code>Unify hostname retrieval across all infrastructure platforms</code></dd></summary>
<hr>

pkg/agent/definitions.go

<ul><li>Removed the <code>getEC2Hostname</code> function which fetched the <code>local-hostname</code> <br>from AWS IMDS.<br> <li> Updated <code>GetHostnameForPlatform</code> to return the system hostname via <br><code>os.Hostname()</code> for all platforms, including EC2.<br> <li> Simplified the logic to ensure consistency with OpenTelemetry resource <br>detection.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/300/files#diff-1e42ad19dedc9981346371b5ce3cb1f18dfd975b58a09ea5576fdd0ed0c94fd1">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

