### PR TITLE
Improve structured logging context across host agent and profiler

### DIFF
--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -380,14 +380,16 @@ func (p *Profiler) StartProfiling(appName string, target string, tags string) {
 	parsedURL, err := url.Parse(target)
 
 	if err != nil {
-		p.Logger.Error("PROFILER: Invalid URL - MW_TARGET")
+		p.Logger.Error("PROFILER: Invalid URL - MW_TARGET",
+			zap.String("target", target), zap.Error(err))
 		return
 	}
 
 	hostParts := strings.Split(parsedURL.Hostname(), ".")
 
 	if len(hostParts) <= 1 {
-		p.Logger.Error("PROFILER: Subdomain doesn't exist - MW_TARGET")
+		p.Logger.Error("PROFILER: Subdomain doesn't exist - MW_TARGET",
+			zap.String("hostname", parsedURL.Hostname()))
 		return
 	}
 

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -630,7 +630,9 @@ func (c *HostAgent) callRestartStatusAPI() error {
 	}
 
 	if apiResponse.Restart {
-		c.logger.Info("fetching updated configuration from backend")
+		c.logger.Info("fetching updated configuration from backend",
+			zap.String("host_id", hostname),
+			zap.String("infra_platform", fmt.Sprint(c.InfraPlatform)))
 		if _, err := c.getOtelConfig(); err != nil {
 			return err
 		}
@@ -815,10 +817,14 @@ func (c *HostAgent) StartCollector() error {
 
 func (c *HostAgent) StopCollector(err error) {
 	if c.collector != nil {
-		c.logger.Error("stopping telemetry collection", zap.Error(err))
+		if errors.Is(err, ErrRestartAgent) {
+			c.logger.Info("stopping telemetry collection for restart")
+		} else {
+			c.logger.Error("stopping telemetry collection", zap.Error(err))
+		}
 		c.collector.Shutdown()
 		c.collectorWG.Wait()
-		c.logger.Info("stopped telemetry collection at", zap.Time("time", time.Now()))
+		c.logger.Info("stopped telemetry collection")
 		c.collector = nil
 	}
 }

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -797,6 +797,7 @@ func (c *HostAgent) StartCollector() error {
 	}
 
 	c.collector = collector
+	c.logger.Info("starting telemetry collection")
 
 	c.collectorWG.Add(1)
 	go func() {


### PR DESCRIPTION

## Improve structured logging context across host agent and profiler

Fixes a few logging blind spots that made debugging harder than it needed to be.

### Changes

**`hostagent.go`**

- **`StopCollector`**: Was logging at `Error` level even for intentional restarts. Now logs `Info` when the stop is triggered by `ErrRestartAgent`, `Error` for everything else.
- **`callRestartStatusAPI`**: Added `host_id` and `infra_platform` fields to the config-fetch log line so you can actually tell *which* host is pulling new config.
- Removed redundant `zap.Time("time", time.Now())` from the "stopped telemetry collection" log. The log framework already timestamps entries.

**`definitions.go`**

- Profiler error logs for invalid `MW_TARGET` now include the actual target URL and parsed hostname. Before this, you'd just get "Invalid URL" with zero context about what was invalid.


___

### **PR Type**
Enhancement


___

### **Description**
- Enhance profiler error logs with target URL and hostname context.

- Add host ID and platform context to agent config-fetch logs.

- Adjust collector stop log levels for intentional restarts.

- Add start log and remove redundant timestamps in telemetry collection.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph HostAgent
    SA["StartCollector"] -- "Log Info" --> SC["Telemetry Started"]
    STC["StopCollector"] -- "Check Error" --> ER{"ErrRestartAgent?"}
    ER -- "Yes" --> LI["Log Info"]
    ER -- "No" --> LE["Log Error"]
  end
  subgraph Profiler
    SP["StartProfiling"] -- "Invalid URL" --> LE2["Log Error with Context"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>definitions.go</strong><dd><code>Add context to profiler initialization error logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/definitions.go

<ul><li>Added <code>target</code> and <code>error</code> context to the "Invalid URL" error log in <br><code>StartProfiling</code>.<br> <li> Added <code>hostname</code> context to the "Subdomain doesn't exist" error log.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/301/files#diff-1e42ad19dedc9981346371b5ce3cb1f18dfd975b58a09ea5576fdd0ed0c94fd1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hostagent.go</strong><dd><code>Improve telemetry collection and config fetch logging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/hostagent.go

<ul><li>Added <code>host_id</code> and <code>infra_platform</code> fields to the configuration fetch log <br>in <code>callRestartStatusAPI</code>.<br> <li> Added a new info log "starting telemetry collection" in <br><code>StartCollector</code>.<br> <li> Updated <code>StopCollector</code> to log at <code>Info</code> level when the stop is due to <br><code>ErrRestartAgent</code>.<br> <li> Removed redundant <code>zap.Time</code> from the "stopped telemetry collection" <br>log.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/301/files#diff-01bb9ad0061934f77631c55d7cb1f494d03732b6f31c8d848504518fd7f51912">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

