### PR TITLE
feat: add receiver health checks with state file and CLI commands

### DIFF
--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -634,6 +634,52 @@ func formatInstrumented(e otelinject.ServiceEntry) string {
 	return "yes"
 }
 
+func listIntegrations(showAll, quiet bool, logger *zap.Logger) error {
+	entries, err := otelinject.DiscoverIntegrations(otelinject.DiscoverIntegrationsOpts{
+		Logger: zapToSlog(logger),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to discover integrations: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No integrations detected.")
+		return nil
+	}
+
+	if quiet {
+		for _, e := range entries {
+			fmt.Println(e.IntegrationType)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	if showAll {
+		fmt.Fprintln(w, "INTEGRATION\tSERVICE NAME\tTYPE\tPORTS\tPID\tOWNER\tSTATUS")
+		for _, e := range entries {
+			for _, inst := range e.Instances {
+				ports := formatPorts(inst.Ports)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					e.IntegrationType, e.ServiceName, e.ServiceType,
+					ports, inst.PID, inst.Owner, inst.Status,
+				)
+			}
+		}
+	} else {
+		fmt.Fprintln(w, "INTEGRATION\tSERVICE NAME\tTYPE\tPORTS\tINSTANCES")
+		for _, e := range entries {
+			ports := formatPorts(e.Ports)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n",
+				e.IntegrationType, e.ServiceName, e.ServiceType,
+				ports, len(e.Instances),
+			)
+		}
+	}
+	return w.Flush()
+}
+
 func main() {
 	zapEncoderCfg := zapcore.EncoderConfig{
 		MessageKey: "message",
@@ -935,6 +981,31 @@ func main() {
 						},
 						Action: func(c *cli.Context) error {
 							return listServices(c.String("language"), c.Bool("all"), c.Bool("quiet"), logger)
+						},
+					},
+				},
+			},
+			{
+				Name:  "integrations",
+				Usage: "Manage detected integrations",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "List detected integrations (databases, message queues, web servers, etc.)",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "all",
+								Aliases: []string{"a"},
+								Usage:   "Show individual instances.",
+							},
+							&cli.BoolFlag{
+								Name:    "quiet",
+								Aliases: []string{"q"},
+								Usage:   "Only display integration types.",
+							},
+						},
+						Action: func(c *cli.Context) error {
+							return listIntegrations(c.Bool("all"), c.Bool("quiet"), logger)
 						},
 					},
 				},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -12,10 +12,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"encoding/json"
 	"text/tabwriter"
 
-	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
+	"github.com/middleware-labs/mw-agent/pkg/healthcheck"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -59,6 +61,10 @@ func (p *program) Start(s service.Service) error {
 
 	p.logger.Info("starting service", zap.Stringer("name", s))
 
+	if err := healthcheck.WriteState(p.hostAgent.OtelConfigFile); err != nil {
+		p.logger.Warn("failed to write agent state file", zap.Error(err))
+	}
+
 	p.programWG.Add(1)
 	go p.run()
 	p.programWG.Add(1)
@@ -85,6 +91,10 @@ func (p *program) Start(s service.Service) error {
 func (p *program) Stop(s service.Service) error {
 	// Stop should not block. Return with a few seconds.
 	p.logger.Info("stopping service", zap.Stringer("name", s))
+
+	if err := healthcheck.RemoveState(); err != nil {
+		p.logger.Warn("failed to remove agent state file", zap.Error(err))
+	}
 
 	// stop collection
 	close(p.stopCh)
@@ -713,6 +723,9 @@ func main() {
 	var cfg agent.HostConfig
 	flags := getFlags(execPath, &cfg)
 
+	const AGENT_HEALTHCHECK_URL = "http://localhost:13133"
+	agentHealthChecker := healthcheck.NewAgentHealthChecker(AGENT_HEALTHCHECK_URL)
+
 	app := &cli.App{
 		Name:  "mw-agent",
 		Usage: "Middleware host agent",
@@ -723,6 +736,7 @@ func main() {
 				Flags:  flags,
 				Before: altsrc.InitInputSourceWithContext(flags, altsrc.NewYamlSourceFromFlagFunc("config-file")),
 				Action: func(c *cli.Context) error {
+
 					loggingLevel, err := zap.ParseAtomicLevel(cfg.LoggingLevel)
 					if err != nil {
 						logger.Error("error getting executable path", zap.Error(err))
@@ -1067,6 +1081,167 @@ func main() {
 					default:
 						return fmt.Errorf("unsupported type %q: must be systemd or obi", deployType)
 					}
+				},
+			},
+			{
+				Name:  "receivers",
+				Usage: "Manage configured receivers (requires running agent)",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "List receivers loaded in the running agent",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "quiet",
+								Aliases: []string{"q"},
+								Usage:   "Only display receiver names",
+							},
+						},
+						Action: func(c *cli.Context) error {
+							err := agentHealthChecker.CheckHealth(c.Context)
+							if err != nil {
+								return fmt.Errorf("Collector HealthCheck failing: %v", err)
+							}
+
+							state, err := healthcheck.ReadState()
+							if err != nil {
+								return err
+							}
+
+							receivers, err := healthcheck.LoadReceivers(state.OtelConfigFile)
+							if err != nil {
+								return err
+							}
+
+							if c.Bool("quiet") {
+								for name := range receivers {
+									fmt.Println(name)
+								}
+								return nil
+							}
+
+							w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+							fmt.Fprintln(w, "RECEIVER\tHEALTH CHECK\tDETAILS")
+							for name, rawCfg := range receivers {
+								hc, err := healthcheck.NewHealthChecker(name, rawCfg)
+								if err != nil {
+									fmt.Fprintf(w, "%s\t-\t%s\n", name, err)
+									continue
+								}
+								if err := hc.CheckHealth(c.Context); err != nil {
+									fmt.Fprintf(w, "%s\tUNHEALTHY\t%s\n", name, err)
+								} else {
+									fmt.Fprintf(w, "%s\tHEALTHY\t\n", name)
+								}
+							}
+							return w.Flush()
+						},
+					},
+					{
+						Name:      "status",
+						Usage:     "Check health of a configured receiver",
+						ArgsUsage: "<receiver-name>",
+						Action: func(c *cli.Context) error {
+							err := agentHealthChecker.CheckHealth(c.Context)
+							if err != nil {
+								return fmt.Errorf("Collector HealthCheck failing: %v", err)
+							}
+
+							name := c.Args().First()
+							if name == "" {
+								return fmt.Errorf("receiver name is required")
+							}
+
+							state, err := healthcheck.ReadState()
+							if err != nil {
+								return err
+							}
+
+							receivers, err := healthcheck.LoadReceivers(state.OtelConfigFile)
+							if err != nil {
+								return err
+							}
+
+							matched := map[string]any{}
+							if rawCfg, ok := receivers[name]; ok {
+								matched[name] = rawCfg
+							} else {
+								for rName, rCfg := range receivers {
+									if strings.HasPrefix(rName, name) {
+										matched[rName] = rCfg
+									}
+								}
+							}
+							if len(matched) == 0 {
+								return fmt.Errorf("receiver %s not found in config", name)
+							}
+
+							var hasErr bool
+							for rName, rawCfg := range matched {
+								hc, err := healthcheck.NewHealthChecker(rName, rawCfg)
+								if err != nil {
+									fmt.Printf("-          %s  %s\n", rName, err)
+									continue
+								}
+								if err := hc.CheckHealth(c.Context); err != nil {
+									fmt.Printf("UNHEALTHY  %s  %s\n", rName, err)
+									hasErr = true
+								} else {
+									fmt.Printf("HEALTHY    %s\n", rName)
+								}
+							}
+							if hasErr {
+								return fmt.Errorf("one or more receivers unhealthy")
+							}
+							return nil
+						},
+					},
+					{
+						Name:      "config",
+						Usage:     "Show config of a configured receiver",
+						ArgsUsage: "<receiver-name>",
+						Action: func(c *cli.Context) error {
+							name := c.Args().First()
+							if name == "" {
+								return fmt.Errorf("receiver name is required")
+							}
+
+							state, err := healthcheck.ReadState()
+							if err != nil {
+								return err
+							}
+
+							receivers, err := healthcheck.LoadReceivers(state.OtelConfigFile)
+							if err != nil {
+								return err
+							}
+
+							matched := map[string]any{}
+							if rawCfg, ok := receivers[name]; ok {
+								matched[name] = rawCfg
+							} else {
+								for rName, rCfg := range receivers {
+									if strings.HasPrefix(rName, name) {
+										matched[rName] = rCfg
+									}
+								}
+							}
+							if len(matched) == 0 {
+								return fmt.Errorf("receiver %s not found in config", name)
+							}
+
+							for rName, rawCfg := range matched {
+								fmt.Printf("--- %s ---\n", rName)
+								out, err := json.MarshalIndent(rawCfg, "", "  ")
+								if err != nil {
+									fmt.Printf("  (could not serialize: %v)\n", err)
+									continue
+								}
+								fmt.Println(string(out))
+							}
+							return nil
+						},
+					},
 				},
 			},
 		},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -1120,21 +1120,39 @@ func main() {
 								return nil
 							}
 
-							w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-							fmt.Fprintln(w, "RECEIVER\tHEALTH CHECK\tDETAILS")
+							var pending []string
+							var skipped []string
+							type checkJob struct {
+								name string
+								hc   healthcheck.HealthChecker
+							}
+							var jobs []checkJob
+
 							for name, rawCfg := range receivers {
 								hc, err := healthcheck.NewHealthChecker(name, rawCfg)
 								if err != nil {
-									fmt.Fprintf(w, "%s\t-\t%s\n", name, err)
+									skipped = append(skipped, name)
 									continue
 								}
-								if err := hc.CheckHealth(c.Context); err != nil {
-									fmt.Fprintf(w, "%s\tUNHEALTHY\t%s\n", name, err)
-								} else {
-									fmt.Fprintf(w, "%s\tHEALTHY\t\n", name)
-								}
+								pending = append(pending, name)
+								jobs = append(jobs, checkJob{name: name, hc: hc})
 							}
-							return w.Flush()
+
+							resultCh := make(chan healthcheck.ReceiverResult, len(jobs))
+							for _, j := range jobs {
+								go func(name string, hc healthcheck.HealthChecker) {
+									if dhc, ok := hc.(healthcheck.DetailedHealthChecker); ok {
+										checks, err := dhc.CheckHealthDetailed(c.Context)
+										resultCh <- healthcheck.ReceiverResult{Name: name, Checks: checks, Err: err}
+									} else {
+										err := hc.CheckHealth(c.Context)
+										resultCh <- healthcheck.ReceiverResult{Name: name, Err: err}
+									}
+								}(j.name, j.hc)
+							}
+
+							healthcheck.RenderResultsStream(pending, skipped, resultCh)
+							return nil
 						},
 					},
 					{
@@ -1176,20 +1194,38 @@ func main() {
 								return fmt.Errorf("receiver %s not found in config", name)
 							}
 
-							var hasErr bool
+							var pending []string
+							var skipped []string
+							type checkJob struct {
+								name string
+								hc   healthcheck.HealthChecker
+							}
+							var jobs []checkJob
+
 							for rName, rawCfg := range matched {
 								hc, err := healthcheck.NewHealthChecker(rName, rawCfg)
 								if err != nil {
-									fmt.Printf("-          %s  %s\n", rName, err)
+									skipped = append(skipped, rName)
 									continue
 								}
-								if err := hc.CheckHealth(c.Context); err != nil {
-									fmt.Printf("UNHEALTHY  %s  %s\n", rName, err)
-									hasErr = true
-								} else {
-									fmt.Printf("HEALTHY    %s\n", rName)
-								}
+								pending = append(pending, rName)
+								jobs = append(jobs, checkJob{name: rName, hc: hc})
 							}
+
+							resultCh := make(chan healthcheck.ReceiverResult, len(jobs))
+							for _, j := range jobs {
+								go func(name string, hc healthcheck.HealthChecker) {
+									if dhc, ok := hc.(healthcheck.DetailedHealthChecker); ok {
+										checks, err := dhc.CheckHealthDetailed(c.Context)
+										resultCh <- healthcheck.ReceiverResult{Name: name, Checks: checks, Err: err}
+									} else {
+										err := hc.CheckHealth(c.Context)
+										resultCh <- healthcheck.ReceiverResult{Name: name, Err: err}
+									}
+								}(j.name, j.hc)
+							}
+
+							hasErr := healthcheck.RenderResultsStream(pending, skipped, resultCh)
 							if hasErr {
 								return fmt.Errorf("one or more receivers unhealthy")
 							}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubel
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-20260203101750-23450dbe285c
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528095250-db345ab6f729
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.0.0-20260512133141-3eb5d9cdf8ee
 

--- a/go.mod
+++ b/go.mod
@@ -120,8 +120,11 @@ require (
 )
 
 require (
+	github.com/goccy/go-yaml v1.18.0
+	github.com/lib/pq v1.10.9
 	github.com/middleware-labs/mw-injector v1.2.3
 	github.com/middleware-labs/synthetics-agent v1.0.63
+	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.139.0
@@ -256,7 +259,6 @@ require (
 	github.com/go-zookeeper/zk v1.0.4 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
@@ -319,7 +321,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-syslog/v4 v4.3.0 // indirect
 	github.com/leodido/ragel-machinery v0.0.0-20190525184631-5f46317e436b // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/likexian/gokit v0.25.15 // indirect
 	github.com/likexian/whois v1.15.5 // indirect
@@ -338,7 +339,6 @@ require (
 	github.com/miekg/dns v1.1.68 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.2.1
+	github.com/middleware-labs/mw-injector v1.2.3
 	github.com/middleware-labs/synthetics-agent v1.0.63
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/microsoft/go-mssqldb v1.9.3 h1:hy4p+LDC8LIGvI3JATnLVmBOLMJbmn5X400mr5
 github.com/microsoft/go-mssqldb v1.9.3/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.2.1 h1:KUHZN61IFIuP31Q8Fxh8xlsqyseyNOSVzqg7BbpmFhk=
-github.com/middleware-labs/java-injector v1.2.1/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
+github.com/middleware-labs/mw-injector v1.2.3 h1:XOK0pj6WemZhGLvg1scc4HIlvkUtBVgVQcXVRqMXZUQ=
+github.com/middleware-labs/mw-injector v1.2.3/go.mod h1:/GBMrvr6uRbOWS9gtjm+5k6HZEfgFL6fZ9+Z3UdDhyM=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de h1:k/6jwD32bI+b4bo+XSSOQQlgTyHUN+xl6xG9t/xB9JI=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:im+Uz25kuqz7p/JaozQqkTeBJkCJMJdCPOEV89LTL9Y=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260122034336-b0dc5b7db4de h1:/cfHWPgdLlZt3XmHQ8XYGV0qBbeFc8kyS4CEFHjcnpU=

--- a/go.sum
+++ b/go.sum
@@ -682,8 +682,8 @@ github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kafkametrics
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:iaLOe9i/mQaQgCpwg9x2uJdLjRTARPkMFsr7p75bttA=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:4ad+C2vySX1P4Iy1q83GQqGuUSvoSVmC8rTpPqfs7kE=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:IGVGI0yoKsigON35IeUjdHYFhJMvzsh0e0hAQJ4gipU=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412 h1:BU8mUR6rPpcKlRgnv9Sp+GN1zHj8Hdjgqz6Q6iHS7QY=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260209135944-83db063de412/go.mod h1:FLnKpVrHf2DoZfc5b0DhAA/GemkrikIyR/N7GZ6F/6o=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528095250-db345ab6f729 h1:O5l77Izsi/44TGkB2mE7PkIV8hiqmhHea+ZiIAlvvSk=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.0.0-20260528095250-db345ab6f729/go.mod h1:FLnKpVrHf2DoZfc5b0DhAA/GemkrikIyR/N7GZ6F/6o=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:wbp2o56VoJclXr4PvCmWX951dcTqyQ5zDH/JQM+t020=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.0.0-20260122034336-b0dc5b7db4de/go.mod h1:/v4rvhGer4DSu6vqw84Sb13IW8isIqqPRqFMsVbld4E=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/nginxreceiver v0.0.0-20260122034336-b0dc5b7db4de h1:YT26bllvJ88Cmis9v9UdNcfpbsUPZOXkhypXo8XDh7Y=

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -304,11 +304,6 @@ func IsEC2Instance() bool {
 	return err == nil
 }
 
-// getEC2Hostname retrieves the internal hostname/FQDN from AWS EC2 metadata service
-func getEC2Hostname() (string, error) {
-	return getEC2Metadata("local-hostname")
-}
-
 func getHostname() string {
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -319,15 +314,6 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
-	// Get EC2 full hostname when running on EC2, otherwise use system hostname
-	if infraPlatform == InfraPlatformEC2 {
-		hostname, err := getEC2Hostname()
-		if err != nil {
-			// Fall back to system hostname if EC2 hostname retrieval fails
-			return getHostname()
-		}
-		return hostname
-	}
 	return getHostname()
 }
 

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -50,6 +50,7 @@ type HostAgent struct {
 	httpGetFunc         func(url string) (resp *http.Response, err error)
 	Version             string
 	applyConfigOnce     sync.Once
+	Receivers           map[string]interface{}
 }
 
 // HostOptions takes in various options for HostAgent

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"

--- a/pkg/healthcheck/agent.go
+++ b/pkg/healthcheck/agent.go
@@ -1,0 +1,66 @@
+package healthcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type HealthCheckResponse struct {
+	statusCode int
+	StatusMsg  string    `json:"status"`
+	UpSince    time.Time `json:"upSince"`
+	Uptime     string    `json:"uptime"`
+}
+
+type AgentHealthChecker struct {
+	endpoint string
+}
+
+func NewAgentHealthChecker(endpoint string) *AgentHealthChecker {
+	return &AgentHealthChecker{endpoint: endpoint}
+}
+
+func (a *AgentHealthChecker) CheckHealth(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("collector not reachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("collector unhealthy: status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (a *AgentHealthChecker) GetStatus(ctx context.Context) (*HealthCheckResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("collector not reachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var hcResp HealthCheckResponse
+	hcResp.statusCode = resp.StatusCode
+	if err := json.NewDecoder(resp.Body).Decode(&hcResp); err != nil {
+		return nil, fmt.Errorf("failed to parse health check response: %w", err)
+	}
+
+	return &hcResp, nil
+}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -25,6 +25,15 @@ func NewHealthChecker(receiverName string, rawCfg any) (HealthChecker, error) {
 			return nil, err
 		}
 		return &cfg, nil
+	case strings.HasPrefix(receiverName, "mongodb"):
+		var cfg MongodbReceiver
+		if err := mapstructure.Decode(rawCfg, &cfg); err != nil {
+			return nil, fmt.Errorf("mongodb: failed to decode config: %w", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
 	default:
 		return nil, fmt.Errorf("healthcheck not implemented for receiver: %s", receiverName)
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -10,8 +10,19 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+type PermissionCheck struct {
+	Name    string
+	Granted bool
+	Err     error
+}
+
 type HealthChecker interface {
 	CheckHealth(ctx context.Context) error
+}
+
+type DetailedHealthChecker interface {
+	HealthChecker
+	CheckHealthDetailed(ctx context.Context) ([]PermissionCheck, error)
 }
 
 func NewHealthChecker(receiverName string, rawCfg any) (HealthChecker, error) {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,39 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	_ "github.com/lib/pq"
+	"github.com/mitchellh/mapstructure"
+)
+
+type HealthChecker interface {
+	CheckHealth(ctx context.Context) error
+}
+
+func NewHealthChecker(receiverName string, rawCfg any) (HealthChecker, error) {
+	switch {
+	case strings.HasPrefix(receiverName, "postgresql"):
+		var cfg PostgresqlReceiver
+		if err := mapstructure.Decode(rawCfg, &cfg); err != nil {
+			return nil, fmt.Errorf("postgresql: failed to decode config: %w", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
+	default:
+		return nil, fmt.Errorf("healthcheck not implemented for receiver: %s", receiverName)
+	}
+}
+
+func parseEndpoint(endpoint, defaultPort string) (host, port string) {
+	h, p, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return endpoint, defaultPort
+	}
+	return h, p
+}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -25,6 +25,15 @@ func NewHealthChecker(receiverName string, rawCfg any) (HealthChecker, error) {
 			return nil, err
 		}
 		return &cfg, nil
+	case strings.HasPrefix(receiverName, "mysql"):
+		var cfg MysqlReceiver
+		if err := mapstructure.Decode(rawCfg, &cfg); err != nil {
+			return nil, fmt.Errorf("mysql: failed to decode config: %w", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
 	case strings.HasPrefix(receiverName, "mongodb"):
 		var cfg MongodbReceiver
 		if err := mapstructure.Decode(rawCfg, &cfg); err != nil {

--- a/pkg/healthcheck/mongodb.go
+++ b/pkg/healthcheck/mongodb.go
@@ -1,0 +1,206 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.uber.org/multierr"
+)
+
+type MongoHost struct {
+	Endpoint string `mapstructure:"endpoint"`
+}
+
+type MongodbReceiver struct {
+	Hosts            []MongoHost `mapstructure:"hosts"`
+	Scheme           string      `mapstructure:"scheme"`
+	Username         string      `mapstructure:"username"`
+	Password         string      `mapstructure:"password"`
+	ReplicaSet       string      `mapstructure:"replica_set,omitempty"`
+	DirectConnection bool        `mapstructure:"direct_connection"`
+}
+
+func (r *MongodbReceiver) Validate() error {
+	if len(r.Hosts) == 0 {
+		return errors.New("mongodb: no hosts configured")
+	}
+
+	var err error
+	for _, h := range r.Hosts {
+		if h.Endpoint == "" {
+			err = multierr.Append(err, errors.New("mongodb: empty endpoint in hosts"))
+		}
+	}
+
+	if r.Scheme != "" && r.Scheme != "mongodb" && r.Scheme != "mongodb+srv" {
+		err = multierr.Append(err, fmt.Errorf("mongodb: invalid scheme %q", r.Scheme))
+	}
+
+	if r.Scheme == "mongodb+srv" && len(r.Hosts) != 1 {
+		err = multierr.Append(err, errors.New("mongodb: mongodb+srv requires exactly one host"))
+	}
+
+	if r.Username != "" && r.Password == "" {
+		err = multierr.Append(err, errors.New("mongodb: username provided without password"))
+	} else if r.Username == "" && r.Password != "" {
+		err = multierr.Append(err, errors.New("mongodb: password provided without username"))
+	}
+
+	return err
+}
+
+func (r *MongodbReceiver) connect(ctx context.Context) (*mongo.Client, error) {
+	scheme := r.Scheme
+	if scheme == "" {
+		scheme = "mongodb"
+	}
+
+	var hostlist []string
+	for _, h := range r.Hosts {
+		hostlist = append(hostlist, h.Endpoint)
+	}
+
+	uri := scheme + "://" + strings.Join(hostlist, ",")
+
+	opts := options.Client().ApplyURI(uri)
+	opts.SetConnectTimeout(5 * time.Second)
+
+	if r.Username != "" && r.Password != "" {
+		opts.SetAuth(options.Credential{
+			Username:   r.Username,
+			Password:   r.Password,
+			AuthSource: "admin",
+		})
+	}
+
+	if r.ReplicaSet != "" {
+		opts.SetReplicaSet(r.ReplicaSet)
+	}
+
+	if r.DirectConnection {
+		opts.SetDirect(true)
+	}
+
+	return mongo.Connect(opts)
+}
+
+func (r *MongodbReceiver) CheckHealth(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := r.connect(ctx)
+	if err != nil {
+		return fmt.Errorf("mongodb: failed to connect: %w", err)
+	}
+	defer client.Disconnect(ctx)
+
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return fmt.Errorf("mongodb: ping failed: %w", err)
+	}
+
+	checks := r.checkPermissions(ctx, client)
+
+	var missing []string
+	for _, c := range checks {
+		if !c.Granted {
+			missing = append(missing, c.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("mongodb: missing permissions: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func (r *MongodbReceiver) checkPermissions(ctx context.Context, client *mongo.Client) []PermissionCheck {
+	checks := []PermissionCheck{
+		{Name: "CONNECT", Granted: true},
+		{Name: "clusterMonitor"},
+		{Name: "dbAdminAnyDatabase"},
+		{Name: "profiling"},
+	}
+
+	var connStatus bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "connectionStatus", Value: 1}}).Decode(&connStatus)
+	if err != nil {
+		for i := 1; i < len(checks); i++ {
+			checks[i].Err = err
+		}
+		return checks
+	}
+
+	roles := extractRoles(connStatus)
+	checks[1].Granted = roles["clusterMonitor"]
+	checks[2].Granted = roles["dbAdminAnyDatabase"]
+	if !checks[1].Granted {
+		checks[1].Err = fmt.Errorf("role not granted to user")
+	}
+	if !checks[2].Granted {
+		checks[2].Err = fmt.Errorf("role not granted to user")
+	}
+
+	var profileStatus bson.M
+	err = client.Database("admin").RunCommand(ctx, bson.D{{Key: "profile", Value: -1}}).Decode(&profileStatus)
+	if err != nil {
+		checks[3].Err = err
+		return checks
+	}
+
+	if was, ok := profileStatus["was"]; ok {
+		level, _ := was.(int32)
+		checks[3].Granted = level > 0
+		if level == 0 {
+			checks[3].Err = fmt.Errorf("profiling is disabled (level 0)")
+		}
+	}
+
+	return checks
+}
+
+func extractRoles(connStatus bson.M) map[string]bool {
+	result := make(map[string]bool)
+
+	authInfo, _ := connStatus["authInfo"]
+	if authInfo == nil {
+		return result
+	}
+
+	var roles bson.A
+	switch ai := authInfo.(type) {
+	case bson.D:
+		for _, elem := range ai {
+			if elem.Key == "authenticatedUserRoles" {
+				roles, _ = elem.Value.(bson.A)
+			}
+		}
+	case bson.M:
+		roles, _ = ai["authenticatedUserRoles"].(bson.A)
+	}
+
+	for _, r := range roles {
+		switch role := r.(type) {
+		case bson.D:
+			for _, field := range role {
+				if field.Key == "role" {
+					if name, ok := field.Value.(string); ok {
+						result[name] = true
+					}
+				}
+			}
+		case bson.M:
+			if name, ok := role["role"].(string); ok {
+				result[name] = true
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/healthcheck/mongodb.go
+++ b/pkg/healthcheck/mongodb.go
@@ -92,20 +92,10 @@ func (r *MongodbReceiver) connect(ctx context.Context) (*mongo.Client, error) {
 }
 
 func (r *MongodbReceiver) CheckHealth(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	client, err := r.connect(ctx)
+	checks, err := r.CheckHealthDetailed(ctx)
 	if err != nil {
-		return fmt.Errorf("mongodb: failed to connect: %w", err)
+		return err
 	}
-	defer client.Disconnect(ctx)
-
-	if err := client.Ping(ctx, readpref.Primary()); err != nil {
-		return fmt.Errorf("mongodb: ping failed: %w", err)
-	}
-
-	checks := r.checkPermissions(ctx, client)
 
 	var missing []string
 	for _, c := range checks {
@@ -120,9 +110,27 @@ func (r *MongodbReceiver) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
+func (r *MongodbReceiver) CheckHealthDetailed(ctx context.Context) ([]PermissionCheck, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := r.connect(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb: failed to connect: %w", err)
+	}
+	defer client.Disconnect(ctx)
+
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return nil, fmt.Errorf("mongodb: ping failed: %w", err)
+	}
+
+	return r.checkPermissions(ctx, client), nil
+}
+
 func (r *MongodbReceiver) checkPermissions(ctx context.Context, client *mongo.Client) []PermissionCheck {
 	checks := []PermissionCheck{
-		{Name: "CONNECT", Granted: true},
+		{Name: "CONNECTED", Granted: true},
+		{Name: "AUTHENTICATED", Granted: true},
 		{Name: "clusterMonitor"},
 		{Name: "dbAdminAnyDatabase"},
 		{Name: "profiling"},
@@ -131,34 +139,34 @@ func (r *MongodbReceiver) checkPermissions(ctx context.Context, client *mongo.Cl
 	var connStatus bson.M
 	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "connectionStatus", Value: 1}}).Decode(&connStatus)
 	if err != nil {
-		for i := 1; i < len(checks); i++ {
+		for i := 2; i < len(checks); i++ {
 			checks[i].Err = err
 		}
 		return checks
 	}
 
 	roles := extractRoles(connStatus)
-	checks[1].Granted = roles["clusterMonitor"]
-	checks[2].Granted = roles["dbAdminAnyDatabase"]
-	if !checks[1].Granted {
-		checks[1].Err = fmt.Errorf("role not granted to user")
-	}
+	checks[2].Granted = roles["clusterMonitor"]
+	checks[3].Granted = roles["dbAdminAnyDatabase"]
 	if !checks[2].Granted {
 		checks[2].Err = fmt.Errorf("role not granted to user")
+	}
+	if !checks[3].Granted {
+		checks[3].Err = fmt.Errorf("role not granted to user")
 	}
 
 	var profileStatus bson.M
 	err = client.Database("admin").RunCommand(ctx, bson.D{{Key: "profile", Value: -1}}).Decode(&profileStatus)
 	if err != nil {
-		checks[3].Err = err
+		checks[4].Err = err
 		return checks
 	}
 
 	if was, ok := profileStatus["was"]; ok {
 		level, _ := was.(int32)
-		checks[3].Granted = level > 0
+		checks[4].Granted = level > 0
 		if level == 0 {
-			checks[3].Err = fmt.Errorf("profiling is disabled (level 0)")
+			checks[4].Err = fmt.Errorf("profiling is disabled (level 0)")
 		}
 	}
 

--- a/pkg/healthcheck/mysql.go
+++ b/pkg/healthcheck/mysql.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/k0kubun/pp"
 	_ "github.com/go-sql-driver/mysql"
 )
 
@@ -28,45 +27,9 @@ func (r *MysqlReceiver) Validate() error {
 }
 
 func (r *MysqlReceiver) CheckHealth(ctx context.Context) error {
-	pp.Println("=== MySQL Health Check ===")
-	pp.Println("Endpoint:", r.Endpoint)
-	pp.Println("Username:", r.Username)
-
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	host, port := parseEndpoint(r.Endpoint, "3306")
-	pp.Println("Parsed host:", host, "port:", port)
-
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/?timeout=5s", r.Username, r.Password, host, port)
-
-	db, err := sql.Open("mysql", dsn)
+	checks, err := r.CheckHealthDetailed(ctx)
 	if err != nil {
-		pp.Println("FAIL: could not open connection:", err)
-		return fmt.Errorf("mysql: failed to open connection: %w", err)
-	}
-	defer db.Close()
-
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(10 * time.Second)
-
-	pp.Println("Pinging database...")
-	if err := db.PingContext(ctx); err != nil {
-		pp.Println("FAIL: ping failed:", err)
-		return fmt.Errorf("mysql: connection failed: %w", err)
-	}
-	pp.Println("OK: connection established")
-
-	pp.Println("Checking permissions...")
-	checks := r.checkPermissions(ctx, db)
-
-	for _, c := range checks {
-		if c.Granted {
-			pp.Println("  ✓", c.Name)
-		} else {
-			pp.Println("  ✗", c.Name, "—", c.Err)
-		}
+		return err
 	}
 
 	var missing []string
@@ -76,79 +39,59 @@ func (r *MysqlReceiver) CheckHealth(ctx context.Context) error {
 		}
 	}
 	if len(missing) > 0 {
-		pp.Println("FAIL: missing permissions:", missing)
 		return fmt.Errorf("mysql: missing permissions: %s", strings.Join(missing, ", "))
 	}
 
-	pp.Println("=== MySQL Health Check PASSED ===")
 	return nil
+}
+
+func (r *MysqlReceiver) CheckHealthDetailed(ctx context.Context) ([]PermissionCheck, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	host, port := parseEndpoint(r.Endpoint, "3306")
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/?timeout=5s", r.Username, r.Password, host, port)
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("mysql: failed to open connection: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("mysql: connection failed: %w", err)
+	}
+
+	return r.checkPermissions(ctx, db), nil
 }
 
 func (r *MysqlReceiver) checkPermissions(ctx context.Context, db *sql.DB) []PermissionCheck {
 	checks := []PermissionCheck{
-		{Name: "CONNECT", Granted: true},
+		{Name: "CONNECTED", Granted: true},
+		{Name: "AUTHENTICATED", Granted: true},
 		{Name: "REPLICATION CLIENT"},
 		{Name: "PROCESS"},
 		{Name: "SELECT ON performance_schema"},
 	}
 
-	// REPLICATION CLIENT — SHOW REPLICA STATUS (8.0.22+) or SHOW SLAVE STATUS (older)
-	pp.Println("Running: SHOW REPLICA STATUS")
-	err := printQueryRows(ctx, db, "SHOW REPLICA STATUS")
+	_, err := db.ExecContext(ctx, "SHOW REPLICA STATUS")
 	if err != nil {
-		pp.Println("Falling back: SHOW SLAVE STATUS")
-		err = printQueryRows(ctx, db, "SHOW SLAVE STATUS")
+		_, err = db.ExecContext(ctx, "SHOW SLAVE STATUS")
 	}
-	checks[1].Granted = err == nil
-	checks[1].Err = err
-
-	// PROCESS — SHOW PROCESSLIST requires it
-	pp.Println("Running: SHOW PROCESSLIST")
-	err = printQueryRows(ctx, db, "SHOW PROCESSLIST")
 	checks[2].Granted = err == nil
 	checks[2].Err = err
 
-	// SELECT on performance_schema
-	pp.Println("Running: SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
-	err = printQueryRows(ctx, db, "SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
+	_, err = db.ExecContext(ctx, "SHOW PROCESSLIST")
 	checks[3].Granted = err == nil
 	checks[3].Err = err
 
+	_, err = db.ExecContext(ctx, "SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
+	checks[4].Granted = err == nil
+	checks[4].Err = err
+
 	return checks
-}
-
-func printQueryRows(ctx context.Context, db *sql.DB, query string) error {
-	rows, err := db.QueryContext(ctx, query)
-	if err != nil {
-		pp.Println("  err:", err)
-		return err
-	}
-	defer rows.Close()
-
-	cols, _ := rows.Columns()
-	pp.Println("  columns:", cols)
-
-	vals := make([]any, len(cols))
-	ptrs := make([]any, len(cols))
-	for i := range vals {
-		ptrs[i] = &vals[i]
-	}
-
-	rowNum := 0
-	for rows.Next() {
-		if err := rows.Scan(ptrs...); err != nil {
-			pp.Println("  scan err:", err)
-			continue
-		}
-		row := make(map[string]any, len(cols))
-		for i, col := range cols {
-			row[col] = vals[i]
-		}
-		pp.Printf("  row[%d]: %v\n", rowNum, row)
-		rowNum++
-	}
-	if rowNum == 0 {
-		pp.Println("  (no rows)")
-	}
-	return rows.Err()
 }

--- a/pkg/healthcheck/mysql.go
+++ b/pkg/healthcheck/mysql.go
@@ -1,0 +1,154 @@
+package healthcheck
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/k0kubun/pp"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type MysqlReceiver struct {
+	Endpoint string `mapstructure:"endpoint"`
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
+}
+
+func (r *MysqlReceiver) Validate() error {
+	if r.Endpoint == "" {
+		return fmt.Errorf("mysql: endpoint not configured")
+	}
+	if r.Username == "" {
+		return fmt.Errorf("mysql: username not configured")
+	}
+	return nil
+}
+
+func (r *MysqlReceiver) CheckHealth(ctx context.Context) error {
+	pp.Println("=== MySQL Health Check ===")
+	pp.Println("Endpoint:", r.Endpoint)
+	pp.Println("Username:", r.Username)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	host, port := parseEndpoint(r.Endpoint, "3306")
+	pp.Println("Parsed host:", host, "port:", port)
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/?timeout=5s", r.Username, r.Password, host, port)
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		pp.Println("FAIL: could not open connection:", err)
+		return fmt.Errorf("mysql: failed to open connection: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	pp.Println("Pinging database...")
+	if err := db.PingContext(ctx); err != nil {
+		pp.Println("FAIL: ping failed:", err)
+		return fmt.Errorf("mysql: connection failed: %w", err)
+	}
+	pp.Println("OK: connection established")
+
+	pp.Println("Checking permissions...")
+	checks := r.checkPermissions(ctx, db)
+
+	for _, c := range checks {
+		if c.Granted {
+			pp.Println("  ✓", c.Name)
+		} else {
+			pp.Println("  ✗", c.Name, "—", c.Err)
+		}
+	}
+
+	var missing []string
+	for _, c := range checks {
+		if !c.Granted {
+			missing = append(missing, c.Name)
+		}
+	}
+	if len(missing) > 0 {
+		pp.Println("FAIL: missing permissions:", missing)
+		return fmt.Errorf("mysql: missing permissions: %s", strings.Join(missing, ", "))
+	}
+
+	pp.Println("=== MySQL Health Check PASSED ===")
+	return nil
+}
+
+func (r *MysqlReceiver) checkPermissions(ctx context.Context, db *sql.DB) []PermissionCheck {
+	checks := []PermissionCheck{
+		{Name: "CONNECT", Granted: true},
+		{Name: "REPLICATION CLIENT"},
+		{Name: "PROCESS"},
+		{Name: "SELECT ON performance_schema"},
+	}
+
+	// REPLICATION CLIENT — SHOW REPLICA STATUS (8.0.22+) or SHOW SLAVE STATUS (older)
+	pp.Println("Running: SHOW REPLICA STATUS")
+	err := printQueryRows(ctx, db, "SHOW REPLICA STATUS")
+	if err != nil {
+		pp.Println("Falling back: SHOW SLAVE STATUS")
+		err = printQueryRows(ctx, db, "SHOW SLAVE STATUS")
+	}
+	checks[1].Granted = err == nil
+	checks[1].Err = err
+
+	// PROCESS — SHOW PROCESSLIST requires it
+	pp.Println("Running: SHOW PROCESSLIST")
+	err = printQueryRows(ctx, db, "SHOW PROCESSLIST")
+	checks[2].Granted = err == nil
+	checks[2].Err = err
+
+	// SELECT on performance_schema
+	pp.Println("Running: SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
+	err = printQueryRows(ctx, db, "SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
+	checks[3].Granted = err == nil
+	checks[3].Err = err
+
+	return checks
+}
+
+func printQueryRows(ctx context.Context, db *sql.DB, query string) error {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		pp.Println("  err:", err)
+		return err
+	}
+	defer rows.Close()
+
+	cols, _ := rows.Columns()
+	pp.Println("  columns:", cols)
+
+	vals := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+
+	rowNum := 0
+	for rows.Next() {
+		if err := rows.Scan(ptrs...); err != nil {
+			pp.Println("  scan err:", err)
+			continue
+		}
+		row := make(map[string]any, len(cols))
+		for i, col := range cols {
+			row[col] = vals[i]
+		}
+		pp.Printf("  row[%d]: %v\n", rowNum, row)
+		rowNum++
+	}
+	if rowNum == 0 {
+		pp.Println("  (no rows)")
+	}
+	return rows.Err()
+}

--- a/pkg/healthcheck/postgres.go
+++ b/pkg/healthcheck/postgres.go
@@ -8,12 +8,6 @@ import (
 	"time"
 )
 
-type PermissionCheck struct {
-	Name    string
-	Granted bool
-	Err     error
-}
-
 type PostgresqlReceiver struct {
 	Endpoint string `mapstructure:"endpoint"`
 	Username string `mapstructure:"username"`
@@ -31,28 +25,10 @@ func (r *PostgresqlReceiver) Validate() error {
 }
 
 func (r *PostgresqlReceiver) CheckHealth(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	host, port := parseEndpoint(r.Endpoint, "5432")
-	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		host, port, r.Username, r.Password)
-
-	db, err := sql.Open("postgres", connStr)
+	checks, err := r.CheckHealthDetailed(ctx)
 	if err != nil {
-		return fmt.Errorf("postgresql: failed to open connection: %w", err)
+		return err
 	}
-	defer db.Close()
-
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(10 * time.Second)
-
-	if err := db.PingContext(ctx); err != nil {
-		return fmt.Errorf("postgresql: connection failed: %w", err)
-	}
-
-	checks := r.checkPermissions(ctx, db)
 
 	var missing []string
 	for _, c := range checks {
@@ -67,21 +43,47 @@ func (r *PostgresqlReceiver) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
+func (r *PostgresqlReceiver) CheckHealthDetailed(ctx context.Context) ([]PermissionCheck, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	host, port := parseEndpoint(r.Endpoint, "5432")
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable connect_timeout=5",
+		host, port, r.Username, r.Password)
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("postgresql: failed to open connection: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("postgresql: connection failed: %w", err)
+	}
+
+	return r.checkPermissions(ctx, db), nil
+}
+
 func (r *PostgresqlReceiver) checkPermissions(ctx context.Context, db *sql.DB) []PermissionCheck {
 	checks := []PermissionCheck{
-		{Name: "CONNECT", Granted: true},
+		{Name: "CONNECTED", Granted: true},
+		{Name: "AUTHENTICATED", Granted: true},
 		{Name: "pg_stat_statements"},
 		{Name: "pg_read_all_stats"},
 	}
 
 	_, err := db.ExecContext(ctx, "SELECT 1 FROM pg_stat_statements LIMIT 1")
-	checks[1].Granted = err == nil
-	checks[1].Err = err
+	checks[2].Granted = err == nil
+	checks[2].Err = err
 
 	var hasRole bool
 	err = db.QueryRowContext(ctx, "SELECT pg_has_role(current_user, 'pg_read_all_stats', 'MEMBER')").Scan(&hasRole)
-	checks[2].Granted = err == nil && hasRole
-	checks[2].Err = err
+	checks[3].Granted = err == nil && hasRole
+	checks[3].Err = err
 
 	return checks
 }

--- a/pkg/healthcheck/postgres.go
+++ b/pkg/healthcheck/postgres.go
@@ -1,0 +1,87 @@
+package healthcheck
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type PermissionCheck struct {
+	Name    string
+	Granted bool
+	Err     error
+}
+
+type PostgresqlReceiver struct {
+	Endpoint string `mapstructure:"endpoint"`
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
+}
+
+func (r *PostgresqlReceiver) Validate() error {
+	if r.Endpoint == "" {
+		return fmt.Errorf("postgresql: endpoint not configured")
+	}
+	if r.Username == "" {
+		return fmt.Errorf("postgresql: username not configured")
+	}
+	return nil
+}
+
+func (r *PostgresqlReceiver) CheckHealth(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	host, port := parseEndpoint(r.Endpoint, "5432")
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable connect_timeout=5",
+		host, port, r.Username, r.Password)
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("postgresql: failed to open connection: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("postgresql: connection failed: %w", err)
+	}
+
+	checks := r.checkPermissions(ctx, db)
+
+	var missing []string
+	for _, c := range checks {
+		if !c.Granted {
+			missing = append(missing, c.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("postgresql: missing permissions: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func (r *PostgresqlReceiver) checkPermissions(ctx context.Context, db *sql.DB) []PermissionCheck {
+	checks := []PermissionCheck{
+		{Name: "CONNECT", Granted: true},
+		{Name: "pg_stat_statements"},
+		{Name: "pg_read_all_stats"},
+	}
+
+	_, err := db.ExecContext(ctx, "SELECT 1 FROM pg_stat_statements LIMIT 1")
+	checks[1].Granted = err == nil
+	checks[1].Err = err
+
+	var hasRole bool
+	err = db.QueryRowContext(ctx, "SELECT pg_has_role(current_user, 'pg_read_all_stats', 'MEMBER')").Scan(&hasRole)
+	checks[2].Granted = err == nil && hasRole
+	checks[2].Err = err
+
+	return checks
+}

--- a/pkg/healthcheck/render.go
+++ b/pkg/healthcheck/render.go
@@ -1,0 +1,258 @@
+package healthcheck
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+var (
+	green  = color.New(color.FgGreen, color.Bold)
+	red    = color.New(color.FgRed, color.Bold)
+	yellow = color.New(color.FgYellow, color.Bold)
+	cyan   = color.New(color.FgCyan, color.Bold)
+	dim    = color.New(color.Faint)
+	bold   = color.New(color.Bold)
+	white  = color.New(color.FgWhite)
+)
+
+var spinner = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+type ReceiverResult struct {
+	Name    string
+	Checks  []PermissionCheck
+	Err     error
+	Skipped bool
+}
+
+func RenderResultsStream(pending []string, skipped []string, resultCh <-chan ReceiverResult) bool {
+	fmt.Println()
+	cyan.Print("  Receiver Health Checks")
+	fmt.Println()
+	dim.Println("  " + strings.Repeat("═", 50))
+
+	var healthy, partial, down int
+	remaining := make(map[string]bool, len(pending))
+	for _, name := range pending {
+		remaining[name] = true
+	}
+
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+	spinIdx := 0
+	done := 0
+	total := len(pending)
+
+	showSpinner := func() {
+		var names []string
+		for _, name := range pending {
+			if remaining[name] {
+				names = append(names, name)
+			}
+		}
+		label := strings.Join(names, ", ")
+		if len(label) > 40 {
+			label = label[:37] + "..."
+		}
+		fmt.Printf("\r\033[2K")
+		dim.Printf("  %s Checking: %s", spinner[spinIdx%len(spinner)], label)
+		spinIdx++
+	}
+
+	showSpinner()
+
+	for done < total {
+		select {
+		case r := <-resultCh:
+			fmt.Printf("\r\033[2K")
+			delete(remaining, r.Name)
+
+			fmt.Println()
+			if r.Err != nil {
+				renderDown(r)
+				down++
+			} else {
+				allOk := true
+				for _, c := range r.Checks {
+					if !c.Granted {
+						allOk = false
+						break
+					}
+				}
+				if allOk {
+					renderHealthy(r)
+					healthy++
+				} else {
+					renderPartial(r)
+					partial++
+				}
+			}
+
+			done++
+			if done < total {
+				showSpinner()
+			}
+
+		case <-ticker.C:
+			if done < total {
+				showSpinner()
+			}
+		}
+	}
+
+	fmt.Printf("\r\033[2K")
+
+	renderSkipped(skipped)
+	renderSummary(healthy, partial, down, len(skipped))
+
+	return partial > 0 || down > 0
+}
+
+func RenderResults(results []ReceiverResult) {
+	var healthy, partial, down int
+	var monitored []ReceiverResult
+	var skippedNames []string
+
+	for _, r := range results {
+		if r.Skipped {
+			skippedNames = append(skippedNames, r.Name)
+			continue
+		}
+		monitored = append(monitored, r)
+	}
+
+	fmt.Println()
+	cyan.Print("  Receiver Health Checks")
+	fmt.Println()
+	dim.Println("  " + strings.Repeat("═", 50))
+
+	for _, r := range monitored {
+		fmt.Println()
+		if r.Err != nil {
+			renderDown(r)
+			down++
+		} else {
+			allOk := true
+			for _, c := range r.Checks {
+				if !c.Granted {
+					allOk = false
+					break
+				}
+			}
+			if allOk {
+				renderHealthy(r)
+				healthy++
+			} else {
+				renderPartial(r)
+				partial++
+			}
+		}
+	}
+
+	renderSkipped(skippedNames)
+	renderSummary(healthy, partial, down, len(skippedNames))
+}
+
+func renderHealthy(r ReceiverResult) {
+	green.Print("  ● ")
+	bold.Print(r.Name)
+	padStatus(r.Name, "HEALTHY", green)
+	renderChecks(r.Checks)
+}
+
+func renderPartial(r ReceiverResult) {
+	yellow.Print("  ● ")
+	bold.Print(r.Name)
+	padStatus(r.Name, "PARTIAL", yellow)
+	renderChecks(r.Checks)
+}
+
+func renderDown(r ReceiverResult) {
+	red.Print("  ● ")
+	bold.Print(r.Name)
+	padStatus(r.Name, "DOWN", red)
+	dim.Printf("    └─ %s\n", trimPrefix(r.Err.Error()))
+}
+
+func renderChecks(checks []PermissionCheck) {
+	for i, c := range checks {
+		connector := "├─"
+		if i == len(checks)-1 {
+			connector = "└─"
+		}
+		if c.Granted {
+			dim.Printf("    %s ", connector)
+			green.Print("✓ ")
+			white.Printf("%s\n", c.Name)
+		} else {
+			dim.Printf("    %s ", connector)
+			red.Print("✗ ")
+			white.Print(c.Name)
+			if c.Err != nil {
+				dim.Printf(" — %s", trimPrefix(c.Err.Error()))
+			}
+			fmt.Println()
+		}
+	}
+}
+
+func renderSkipped(names []string) {
+	if len(names) == 0 {
+		return
+	}
+
+	sort.Strings(names)
+
+	fmt.Println()
+	dim.Println("  ── Health check not implemented " + strings.Repeat("─", 19))
+
+	line := "  "
+	for i, name := range names {
+		addition := name
+		if i < len(names)-1 {
+			addition += " · "
+		}
+		if len(line)+len(addition) > 60 {
+			dim.Println(line)
+			line = "  "
+		}
+		line += addition
+	}
+	if len(line) > 2 {
+		dim.Println(line)
+	}
+}
+
+func renderSummary(healthy, partial, down, skipped int) {
+	fmt.Println()
+	dim.Print("  Summary: ")
+	green.Printf("%d healthy", healthy)
+	dim.Print(" · ")
+	yellow.Printf("%d partial", partial)
+	dim.Print(" · ")
+	red.Printf("%d down", down)
+	dim.Print(" · ")
+	dim.Printf("%d skipped", skipped)
+	fmt.Println()
+	fmt.Println()
+}
+
+func padStatus(name, status string, c *color.Color) {
+	padding := 48 - len(name) - len(status)
+	if padding < 2 {
+		padding = 2
+	}
+	fmt.Print(strings.Repeat(" ", padding))
+	c.Println(status)
+}
+
+func trimPrefix(s string) string {
+	prefixes := []string{"postgresql: ", "mongodb: ", "mysql: "}
+	for _, p := range prefixes {
+		s = strings.TrimPrefix(s, p)
+	}
+	return s
+}

--- a/pkg/healthcheck/state.go
+++ b/pkg/healthcheck/state.go
@@ -1,0 +1,86 @@
+package healthcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/goccy/go-yaml"
+)
+
+type AgentState struct {
+	PID            int    `json:"pid"`
+	OtelConfigFile string `json:"otel_config_file"`
+}
+
+func statePath() string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(os.Getenv("ProgramData"), "mw-agent", "agent.state")
+	default:
+		return "/var/run/mw-agent/agent.state"
+	}
+}
+
+func WriteState(otelConfigFile string) error {
+	path := statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	state := AgentState{
+		PID:            os.Getpid(),
+		OtelConfigFile: otelConfigFile,
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	return os.Rename(tmp, path)
+}
+
+func ReadState() (*AgentState, error) {
+	data, err := os.ReadFile(statePath())
+	if err != nil {
+		return nil, fmt.Errorf("agent state not found (is the agent running?): %w", err)
+	}
+
+	var state AgentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse agent state: %w", err)
+	}
+
+	return &state, nil
+}
+
+func RemoveState() error {
+	return os.Remove(statePath())
+}
+
+func LoadReceivers(otelConfigFile string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(otelConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read otel config %s: %w", otelConfigFile, err)
+	}
+
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse otel config: %w", err)
+	}
+
+	receivers, ok := cfg["receivers"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("no receivers found in config")
+	}
+
+	return receivers, nil
+}


### PR DESCRIPTION
  - Add `pkg/healthcheck` package with strategy pattern for per-receiver health checks
    - **PostgreSQL**: connection ping + permission validation (`pg_stat_statements`,
  `pg_read_all_stats`)
    - **MongoDB**: connection ping + role validation (`clusterMonitor`, `dbAdminAnyDatabase`)
  + profiling status check
    - **MySQL**: connection ping + permission validation (`REPLICATION CLIENT`, `PROCESS`,
  `SELECT ON performance_schema`)
    - **Agent/Collector**: hits the built-in health check extension at `:13133`
  - Add state file (`/var/run/mw-agent/agent.state`) written on service start, removed on
  stop — lets CLI commands (separate processes) discover the running agent's otel config path
  - Wire up three new CLI subcommands under `mw-agent receivers`:
    - `list` — all receivers with health check status
    - `status <name>` — check health of matched receivers (prefix matching for multi-instance
  e.g. `postgresql` matches `postgresql/1`, `postgresql/2`)
    - `config <name>` — dump raw config of matched receivers as JSON
  - Add streaming TUI with color-coded output (`fatih/color`), parallel health checks, and
  braille spinner for pending receivers
  - Introduce `DetailedHealthChecker` interface for per-check granularity with `CONNECTED`,
  `AUTHENTICATED`, and permission-level checks
  - Use `PARTIAL` status for receivers with missing permissions, `DOWN` for connection
  failures

  ## Test plan

  - [ ] Start agent with a PostgreSQL receiver configured, verify
  `/var/run/mw-agent/agent.state` is created
  - [ ] Run `mw-agent receivers list` — confirm TUI shows all receivers with
  HEALTHY/PARTIAL/DOWN status
  - [ ] Run `mw-agent receivers status postgresql` — confirm all postgresql instances are
  checked
  - [ ] Run `mw-agent receivers status mongodb` — confirm connection, roles, and profiling
  are validated
  - [ ] Run `mw-agent receivers status mysql` — confirm connection and permissions are
  validated
  - [ ] Run `mw-agent receivers config postgresql` — confirm JSON config is printed for each
  match
  - [ ] Stop agent, verify state file is removed
  - [ ] Run `mw-agent receivers list` without agent running — confirm clear error message
  - [ ] Test with a PostgreSQL user missing `pg_read_all_stats` — confirm PARTIAL with
  missing permission listed
  - [ ] Test with a MongoDB user missing `clusterMonitor` role — confirm PARTIAL with missing
  permission listed
  - [ ] Test with MongoDB profiling disabled — confirm PARTIAL reporting profiling is
  disabled
  - [ ] Test with a MySQL user missing `REPLICATION CLIENT` — confirm PARTIAL with missing
  permission listed