### PR TITLE
AGE-474 : add mysqlreceiver factory in kubeagent

### DIFF
--- a/metadata/base/metrics.json
+++ b/metadata/base/metrics.json
@@ -13,7 +13,8 @@
             "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml",
             "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml",
             "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml",
-            "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml"
+            "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml",
+            "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/processor/resourcedetectionprocessor/internal/system/metadata.yaml"
         ],
         "collection_interval": "15s"
     },

--- a/pkg/agent/kubeagent.go
+++ b/pkg/agent/kubeagent.go
@@ -39,6 +39,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
@@ -201,6 +202,7 @@ func (k *KubeAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 		elasticsearchreceiver.NewFactory(),
 		redisreceiver.NewFactory(),
 		zookeeperreceiver.NewFactory(),
+		mysqlreceiver.NewFactory(),
 	}
 
 	for _, f := range receiverfactories {

--- a/pkg/agent/kubeagent_test.go
+++ b/pkg/agent/kubeagent_test.go
@@ -36,7 +36,7 @@ func TestKubeAgentGetFactories(t *testing.T) {
 	assert.Len(t, factories.Extensions, 1)
 
 	// check if factories contains expected receivers
-	assert.Len(t, factories.Receivers, 22)
+	assert.Len(t, factories.Receivers, 23)
 	assertContainsComponent(t, factories.Receivers, "otlp")
 	assertContainsComponent(t, factories.Receivers, "fluentforward")
 	assertContainsComponent(t, factories.Receivers, "filelog")
@@ -56,6 +56,7 @@ func TestKubeAgentGetFactories(t *testing.T) {
 	assertContainsComponent(t, factories.Receivers, "postgresql")
 	assertContainsComponent(t, factories.Receivers, "elasticsearch")
 	assertContainsComponent(t, factories.Receivers, "redis")
+	assertContainsComponent(t, factories.Receivers, "mysql")
 	assertContainsComponent(t, factories.Receivers, "zookeeper")
 
 	// check if factories contain expected exporters


### PR DESCRIPTION
### **User description**
## Changes :
- Add `mysqlreceiver` factory to kubeagent.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mysqlreceiver` factory to `kubeagent`.

- Enable MySQL monitoring capabilities in the agent.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  KubeAgent["KubeAgent"] -- "registers" --> MySQLReceiver["MySQL Receiver Factory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubeagent.go</strong><dd><code>Register MySQL receiver factory in KubeAgent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/kubeagent.go

<ul><li>Added the <code>mysqlreceiver</code> package to the imports list.<br> <li> Included <code>mysqlreceiver.NewFactory()</code> in the <code>receiverfactories</code> slice <br>within the <code>GetFactories</code> function.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/306/files#diff-5608a9eeeefcf95e4c068ecee730b00c7ad1db8303a7139c836036060c60eaab">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

