### PR TITLE
Fixed telemetry factory for k8s agent

### DIFF
--- a/pkg/agent/kubeagent.go
+++ b/pkg/agent/kubeagent.go
@@ -61,6 +61,7 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -168,6 +169,7 @@ func (k *KubeAgent) GetFactories(_ context.Context) (otelcol.Factories, error) {
 		Receivers:  make(map[component.Type]receiver.Factory),
 		Exporters:  make(map[component.Type]exporter.Factory),
 		Processors: make(map[component.Type]processor.Factory),
+		Telemetry:  otelconftelemetry.NewFactory(),
 	}
 	factories.Extensions = make(map[component.Type]extension.Factory)
 	exts := []extension.Factory{


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Initialize telemetry factory in Kubernetes agent.

- Add `otelconftelemetry` import for factory setup.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  KA["KubeAgent"] -- "calls" --> GF["GetFactories"]
  GF -- "configures" --> TF["Telemetry Factory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubeagent.go</strong><dd><code>Add telemetry factory to `GetFactories`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/kubeagent.go

<ul><li>Imported the <code>otelconftelemetry</code> package from the OpenTelemetry <br>collector service.<br> <li> Updated the <code>GetFactories</code> function to initialize the <code>Telemetry</code> field in <br>the <code>otelcol.Factories</code> struct using <code>otelconftelemetry.NewFactory()</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/309/files#diff-5608a9eeeefcf95e4c068ecee730b00c7ad1db8303a7139c836036060c60eaab">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

