### PR TITLE
Error handling flow updated to catch silent shutdowns in agent logs

### DIFF
--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -111,6 +111,12 @@ func (p *program) run() {
 			continue
 		}
 
+		if errors.Is(err, agent.ErrConfigFetchFailure) {
+			p.logger.Error("failed to fetch or build otel config; keeping collector in its current state",
+				zap.Error(err))
+			continue
+		}
+
 		if err != nil {
 			// stop collection only if it's running
 			p.hostAgent.StopCollector(err)

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -35,6 +35,10 @@ var (
 	ErrRestartAgent     = errors.New("restart agent due to config change")
 	ErrInvalidConfig    = errors.New("invalid config received from backend")
 	ErrReportApiFailure = errors.New("failed to report service discovery status to backend")
+	// ErrConfigFetchFailure covers failures to fetch or build the otel config
+	// (network, parsing, provider errors) as opposed to ErrInvalidConfig, which
+	// is a config that was successfully built but fails schema validation.
+	ErrConfigFetchFailure = errors.New("failed to fetch or build otel config")
 )
 
 // HostAgent implements Agent interface for Hosts (e.g Linux)
@@ -539,7 +543,10 @@ func (c *HostAgent) getOtelConfig() (string, error) {
 	}
 
 	if err := c.updateConfigFile(configType); err != nil {
-		return c.OtelConfigFile, err
+		if errors.Is(err, ErrInvalidConfig) {
+			return c.OtelConfigFile, err
+		}
+		return c.OtelConfigFile, fmt.Errorf("%w: %v", ErrConfigFetchFailure, err)
 	}
 
 	return c.OtelConfigFile, nil
@@ -820,7 +827,9 @@ func (c *HostAgent) StopCollector(err error) {
 		c.collectorWG.Wait()
 		c.logger.Info("stopped telemetry collection at", zap.Time("time", time.Now()))
 		c.collector = nil
+		return
 	}
+	c.logger.Error("received error while telemetry collection is not running", zap.Error(err))
 }
 
 func (c *HostAgent) fixTelemetryConfig(config map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
### **User description**
Solving Issue 4 under [AGE-477](https://linear.app/middleware/issue/AGE-477/optimize-otel-configyaml-to-solve-a-bunch-of-hidden-warnings)

 1. pkg/agent/hostagent.go — added ErrConfigFetchFailure sentinel, distinct from ErrInvalidConfig (network/parse/provider errors vs. a successfully-built
  config that fails schema validation).
  2. getOtelConfig — wraps any updateConfigFile error that isn't already ErrInvalidConfig with ErrConfigFetchFailure.
  3. StopCollector — now always logs the error it receives, even when the collector was never running (previously silently dropped in that case — the
  actual bug you hit at line 517).
  4. cmd/host-agent/main.go — run() now catches ErrConfigFetchFailure explicitly: logs it and continues without tearing down a currently-healthy
  collector, matching how ErrInvalidConfig/ErrReportApiFailure are already handled.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced `ErrConfigFetchFailure` to distinguish fetch errors from validation.

- Updated `main.go` to handle fetch failures gracefully.

- Enhanced `StopCollector` logging for inactive collectors.

- Updated OTel dependencies to fix `kubeletstats` crash.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["getOtelConfig"] -- "wraps error" --> Err["ErrConfigFetchFailure"]
  Err -- "handled by" --> Main["main.go run loop"]
  Main -- "action" --> Log["Log & Continue"]
  Stop["StopCollector"] -- "logs error" --> Debug["Improved Debugging"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Handle OTel config fetch failures in main loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/host-agent/main.go

<ul><li>Added an explicit check for <code>agent.ErrConfigFetchFailure</code> in the <code>run</code> <br>loop.<br> <li> The agent now logs the error and continues execution instead of <br>stopping the collector when a fetch failure occurs.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/311/files#diff-eb82aa5ee7274afbde953137c719decba139e0b2422f0565b40681f335cd5a4a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hostagent.go</strong><dd><code>Define new error type and improve collector logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/hostagent.go

<ul><li>Defined <code>ErrConfigFetchFailure</code> as a new sentinel error for network or <br>parsing issues.<br> <li> Modified <code>getOtelConfig</code> to wrap errors from <code>updateConfigFile</code> with the <br>new sentinel.<br> <li> Updated <code>StopCollector</code> to log received errors even if the collector <br>instance is not currently running.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/311/files#diff-01bb9ad0061934f77631c55d7cb1f494d03732b6f31c8d848504518fd7f51912">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update OpenTelemetry collector dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated multiple <code>replace</code> directives for OpenTelemetry collector <br>contrib modules to a newer version.<br> <li> These updates target a fix for a crash in the <code>kubeletstats</code> receiver.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/311/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

