### PR TITLE
Reviving missing code for ECS Host name + Integration Discovery

### DIFF
--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -640,6 +640,52 @@ func formatInstrumented(e otelinject.ServiceEntry) string {
 	return "yes"
 }
 
+func listIntegrations(showAll, quiet bool, logger *zap.Logger) error {
+	entries, err := otelinject.DiscoverIntegrations(otelinject.DiscoverIntegrationsOpts{
+		Logger: zapToSlog(logger),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to discover integrations: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No integrations detected.")
+		return nil
+	}
+
+	if quiet {
+		for _, e := range entries {
+			fmt.Println(e.IntegrationType)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	if showAll {
+		fmt.Fprintln(w, "INTEGRATION\tSERVICE NAME\tTYPE\tPORTS\tPID\tOWNER\tSTATUS")
+		for _, e := range entries {
+			for _, inst := range e.Instances {
+				ports := formatPorts(inst.Ports)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					e.IntegrationType, e.ServiceName, e.ServiceType,
+					ports, inst.PID, inst.Owner, inst.Status,
+				)
+			}
+		}
+	} else {
+		fmt.Fprintln(w, "INTEGRATION\tSERVICE NAME\tTYPE\tPORTS\tINSTANCES")
+		for _, e := range entries {
+			ports := formatPorts(e.Ports)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n",
+				e.IntegrationType, e.ServiceName, e.ServiceType,
+				ports, len(e.Instances),
+			)
+		}
+	}
+	return w.Flush()
+}
+
 func main() {
 	zapEncoderCfg := zapcore.EncoderConfig{
 		MessageKey: "message",
@@ -941,6 +987,31 @@ func main() {
 						},
 						Action: func(c *cli.Context) error {
 							return listServices(c.String("language"), c.Bool("all"), c.Bool("quiet"), logger)
+						},
+					},
+				},
+			},
+			{
+				Name:  "integrations",
+				Usage: "Manage detected integrations",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "List detected integrations (databases, message queues, web servers, etc.)",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "all",
+								Aliases: []string{"a"},
+								Usage:   "Show individual instances.",
+							},
+							&cli.BoolFlag{
+								Name:    "quiet",
+								Aliases: []string{"q"},
+								Usage:   "Only display integration types.",
+							},
+						},
+						Action: func(c *cli.Context) error {
+							return listIntegrations(c.Bool("all"), c.Bool("quiet"), logger)
 						},
 					},
 				},

--- a/cmd/host-agent/main.go
+++ b/cmd/host-agent/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"github.com/middleware-labs/mw-agent/pkg/agent"
 	"github.com/middleware-labs/synthetics-agent/pkg/worker"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 require (
-	github.com/middleware-labs/java-injector v1.2.1
+	github.com/middleware-labs/mw-injector v1.2.3
 	github.com/middleware-labs/synthetics-agent v1.0.63
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.152.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.152.0

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/microsoft/go-mssqldb v1.9.6 h1:1MNQg5UiSsokiPz3++K2KPx4moKrwIqly1wv+R
 github.com/microsoft/go-mssqldb v1.9.6/go.mod h1:yYMPDufyoF2vVuVCUGtZARr06DKFIhMrluTcgWlXpr4=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266 h1:X/xVGWjivIA2OK+7BbKL7WH6ZrryGTqxmRUwrKoDQ6E=
 github.com/middleware-labs/innoParser v0.0.0-20240729092319-ddbdd8e42266/go.mod h1:K2Iq9MJAEQyQO+ZXQHraf1zxZgS+bRgv/D6p+ClJWRM=
-github.com/middleware-labs/java-injector v1.2.1 h1:KUHZN61IFIuP31Q8Fxh8xlsqyseyNOSVzqg7BbpmFhk=
-github.com/middleware-labs/java-injector v1.2.1/go.mod h1:V26ifM8TKLRy5qgY++z6AQGr5U2FEnd0e9dXcHsMpp0=
+github.com/middleware-labs/mw-injector v1.2.3 h1:XOK0pj6WemZhGLvg1scc4HIlvkUtBVgVQcXVRqMXZUQ=
+github.com/middleware-labs/mw-injector v1.2.3/go.mod h1:/GBMrvr6uRbOWS9gtjm+5k6HZEfgFL6fZ9+Z3UdDhyM=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260705161949-1d113a1a09da h1:uxNxbSlMr6ujxG0n0ePs5sPlmiH4eyUX99NHDkhs4BA=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260705161949-1d113a1a09da/go.mod h1:Z1jfBF4hQkGUtUAS13TW3mtVT7Lk742sHaLqwrljDn0=
 github.com/middleware-labs/opentelemetry-collector-contrib/internal/filter v0.0.0-20260705161949-1d113a1a09da h1:IxwSoOfqh1zKSX1bRpgeuKxh0PrrJVs1mhTIVXmjNqo=

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -304,11 +304,6 @@ func IsEC2Instance() bool {
 	return err == nil
 }
 
-// getEC2Hostname retrieves the internal hostname/FQDN from AWS EC2 metadata service
-func getEC2Hostname() (string, error) {
-	return getEC2Metadata("local-hostname")
-}
-
 func getHostname() string {
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -319,15 +314,6 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
-	// Get EC2 full hostname when running on EC2, otherwise use system hostname
-	if infraPlatform == InfraPlatformEC2 {
-		hostname, err := getEC2Hostname()
-		if err != nil {
-			// Fall back to system hostname if EC2 hostname retrieval fails
-			return getHostname()
-		}
-		return hostname
-	}
 	return getHostname()
 }
 

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go"
-	"github.com/k0kubun/pp"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 )
@@ -315,7 +314,6 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
-	pp.Println("HOSTNAME::::::>>>>>>", getHostname())
 	return getHostname()
 }
 

--- a/pkg/agent/definitions.go
+++ b/pkg/agent/definitions.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go"
+	"github.com/k0kubun/pp"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 )
@@ -314,6 +315,7 @@ func getHostname() string {
 
 // GetHostnameForPlatform returns hostname based on the infra platform
 func GetHostnameForPlatform(infraPlatform InfraPlatform) string {
+	pp.Println("HOSTNAME::::::>>>>>>", getHostname())
 	return getHostname()
 }
 

--- a/pkg/agent/hostagent.go
+++ b/pkg/agent/hostagent.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/middleware-labs/java-injector/pkg/otelinject"
+	"github.com/middleware-labs/mw-injector/pkg/otelinject"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"


### PR DESCRIPTION
Seems that code of PR #299 and #300 is missing due to a recent force push
Cherry-picking changes for including latest updates from `mw-injector`
