### PR TITLE
AGE-516 : Added Memory limit in systemctl service

### DIFF
--- a/package-tooling/linux/mw-agent.service
+++ b/package-tooling/linux/mw-agent.service
@@ -3,6 +3,9 @@ Description=Middleware Agent Service
 After=network.target
 
 [Service]
+MemoryMax=1G
+MemoryHigh=750M
+
 EnvironmentFile=/etc/mw-agent/mw-agent.env
 WorkingDirectory=/opt/mw-agent
 User=root


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added memory limits to systemd service.

- Set `MemoryMax` to 1G.

- Set `MemoryHigh` to 750M.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Service["mw-agent.service"] -- "Add resource constraints" --> Limits["MemoryMax & MemoryHigh"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw-agent.service</strong><dd><code>Add memory resource constraints to systemd service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package-tooling/linux/mw-agent.service

<ul><li>Added <code>MemoryMax=1G</code> to define the hard memory limit for the service.<br> <li> Added <code>MemoryHigh=750M</code> to set a high memory threshold for throttling.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/316/files#diff-dbe9f77258eee042b9939548cbf80c0a957c5584649b2d714d88c1e03816a822">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

