### PR TITLE
[receiver/dockerstats] : Add container.health.status metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostm
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker => github.com/middleware-labs/opentelemetry-collector-contrib/internal/docker v0.0.0-20260705161949-1d113a1a09da
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260705161949-1d113a1a09da
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260805084020-adbed6abfb0a
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver => github.com/middleware-labs/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-20260705161949-1d113a1a09da
 

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/middleware-labs/opentelemetry-collector-contrib/processor/transformpr
 github.com/middleware-labs/opentelemetry-collector-contrib/processor/transformprocessor v0.0.0-20260705161949-1d113a1a09da/go.mod h1:zPAPOXJgOvZIQ+eq+d/GzbHGyHDXiDDEOuZtOYG7Qcg=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/apachereceiver v0.0.0-20260705161949-1d113a1a09da h1:X8OLG3h7A6OQ9mD0ktFlyT0hx2OoJKMvAG16eP7vua4=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/apachereceiver v0.0.0-20260705161949-1d113a1a09da/go.mod h1:Q+rUYZQcarsh1ckZqp21v0Ygf4ARgFDmx78xRuJUtvY=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260705161949-1d113a1a09da h1:uQCcxl2CjGlkA7kLfI9uaolzBWE+x0r2Ge1QZmJbyGQ=
-github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260705161949-1d113a1a09da/go.mod h1:v2SPq9zDKrcxJwGX+PD3WQjhTNRGwSGqgY3LMtfj6iE=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260805084020-adbed6abfb0a h1:1N2RgCJUHo2yYQXMN6VuiycRzaaByreZ1eojeU71jiQ=
+github.com/middleware-labs/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-20260805084020-adbed6abfb0a/go.mod h1:v2SPq9zDKrcxJwGX+PD3WQjhTNRGwSGqgY3LMtfj6iE=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.0.0-20260705161949-1d113a1a09da h1:hxhAsmykH/WCH+zW6KU43RM7n423HYyBR+KAnKBgyBI=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.0.0-20260705161949-1d113a1a09da/go.mod h1:h/k8GI0l2KQ35aOyhy1xcsPKr4pjrpKwTpY7qaSXO6w=
 github.com/middleware-labs/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-20260705161949-1d113a1a09da h1:dzNzIQRpWX53kFiacwtLFKzH0Cr8yc793tJs0T6/kcw=


### PR DESCRIPTION
### **User description**
Ref : [AGE-51](https://linear.app/middleware/issue/AGE-514/need-to-collect-docker-healthy-unhealthy-status)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `container.health.status` metric to the `dockerstatsreceiver`.

- Update the `dockerstatsreceiver` dependency version in `go.mod`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  node1["go.mod"] -- "updates dependency" --> node2["dockerstatsreceiver"]
  node2 -- "implements" --> node3["container.health.status metric"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update `dockerstatsreceiver` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated the <code>replace</code> directive for <br><code>github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver</code>.<br> <li> Bumped the version from <code>v0.0.0-20260705161949-1d113a1a09da</code> to <br><code>v0.0.0-20260805084020-adbed6abfb0a</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/318/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

