### PR TITLE
AGE-516 : Updating Windows build workflow to use native digicert actions

### DIFF
--- a/.github/workflows/host-agent-windows.yaml
+++ b/.github/workflows/host-agent-windows.yaml
@@ -31,21 +31,29 @@ jobs:
         ssh-key: ${{ secrets.CHECK_AGENT_ACCESS }}
         submodules: 'recursive'
 
-    - name: Setup KeyLocker Client Authentication Certificate
+    - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
       run: |
-        echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > client_auth_cert.p12
+        echo "SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/sm_client_cert.p12" >> "$GITHUB_ENV"
+        echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > "${RUNNER_TEMP}/sm_client_cert.p12"
 
-    - name: Debug DigiCert API from runner
+    - name: Debug - list DigiCert keypairs visible to these credentials
       run: |
-        curl -sv -o response.json -w "\nHTTP_STATUS: %{http_code}\n" \
-          --cert client_auth_cert.p12:"${{ secrets.SM_CLIENT_CERT_PASSWORD }}" --cert-type P12 \
-          -H "x-api-key: ${{ secrets.SM_API_KEY }}" \
-          "https://clientauth.one.digicert.com/signingmanager/api/v1/account/keypairs/alias/${{ secrets.SM_KEYPAIR_ALIAS }}"
-        echo "---- response body ----"
-        cat response.json
+        curl -fsSL https://pki-downloads.digicert.com/stm/latest/smctl -o smctl_debug
+        chmod +x smctl_debug
+        ./smctl_debug keypair ls
+      env:
+        SM_HOST: ${{ secrets.SM_HOST }}
+        SM_API_KEY: ${{ secrets.SM_API_KEY }}
+        SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+        SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
-    - name: Install makensis
-      run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
+    - name: Install makensis (NSIS 3.12)
+      run: |
+        curl -sL -o /tmp/nsis-bundle.tar.gz "https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis%402.0.1/nsis-bundle-3.12.tar.gz"
+        tar -xzf /tmp/nsis-bundle.tar.gz -C /tmp
+        chmod +x /tmp/nsis-bundle/linux/x64/makensis
+        echo "NSISDIR=/tmp/nsis-bundle/windows" >> "$GITHUB_ENV"
+        echo "/tmp/nsis-bundle/linux/x64" >> "$GITHUB_PATH"
       if: ${{ matrix.os == 'ubuntu-22.04' }}
 
     - name: Set up Go
@@ -72,18 +80,17 @@ jobs:
         GOOS=windows CGO_ENABLED=0 GOPRIVATE=github.com/middleware-labs go build -ldflags "-s -w -X main.agentVersion=${{ env.RELEASE_VERSION }}" -o build/mw-windows-agent.exe cmd/host-agent/main.go
         makensis -DVERSION=${{ env.RELEASE_VERSION }} package-tooling/windows/package-windows.nsi
 
-    - name: Install jsign Tool For Microsoft Authenticode
-      run: |
-        wget https://github.com/ebourg/jsign/releases/download/7.4/jsign_7.4_all.deb
-        sudo dpkg -i jsign_7.4_all.deb
-
     - name: Sign MW Agent Installer Package
-      run: |
-        jsign --storetype DIGICERTONE \
-              --alias "${{ secrets.SM_KEYPAIR_ALIAS }}" \
-              --tsaurl "${{ secrets.SM_TIMESTAMP_AUTHORITY_URL }}" \
-              --storepass "${{ secrets.SM_API_KEY }}|./client_auth_cert.p12|${{ secrets.SM_CLIENT_CERT_PASSWORD }}" \
-              package-tooling/windows/mw-windows-agent-${{ env.RELEASE_VERSION }}-setup.exe
+      uses: digicert/code-signing-software-trust-action@v1
+      with:
+        simple-signing-mode: true
+        input: package-tooling/windows/mw-windows-agent-${{ env.RELEASE_VERSION }}-setup.exe
+        keypair-alias: ${{ secrets.SM_KEYPAIR_ALIAS }}
+      env:
+        SM_HOST: ${{ secrets.SM_HOST }}
+        SM_API_KEY: ${{ secrets.SM_API_KEY }}
+        SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+        SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/host-agent-windows.yaml
+++ b/.github/workflows/host-agent-windows.yaml
@@ -31,6 +31,19 @@ jobs:
         ssh-key: ${{ secrets.CHECK_AGENT_ACCESS }}
         submodules: 'recursive'
 
+    - name: Setup KeyLocker Client Authentication Certificate
+      run: |
+        echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > client_auth_cert.p12
+
+    - name: Debug DigiCert API from runner
+      run: |
+        curl -sv -o response.json -w "\nHTTP_STATUS: %{http_code}\n" \
+          --cert client_auth_cert.p12:"${{ secrets.SM_CLIENT_CERT_PASSWORD }}" --cert-type P12 \
+          -H "x-api-key: ${{ secrets.SM_API_KEY }}" \
+          "https://clientauth.one.digicert.com/signingmanager/api/v1/account/keypairs/alias/${{ secrets.SM_KEYPAIR_ALIAS }}"
+        echo "---- response body ----"
+        cat response.json
+
     - name: Install makensis
       run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
       if: ${{ matrix.os == 'ubuntu-22.04' }}
@@ -45,7 +58,7 @@ jobs:
         git config --global url."https://${{ secrets.GHCR_TOKEN }}:@github.com/".insteadOf "https://github.com/"
       env:
         GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
-    
+
     - name: Setting Release Number
       run: |
         if [ -n "${{ github.event.inputs.release_version }}" ]; then
@@ -58,15 +71,11 @@ jobs:
       run: |
         GOOS=windows CGO_ENABLED=0 GOPRIVATE=github.com/middleware-labs go build -ldflags "-s -w -X main.agentVersion=${{ env.RELEASE_VERSION }}" -o build/mw-windows-agent.exe cmd/host-agent/main.go
         makensis -DVERSION=${{ env.RELEASE_VERSION }} package-tooling/windows/package-windows.nsi
-       
+
     - name: Install jsign Tool For Microsoft Authenticode
       run: |
         wget https://github.com/ebourg/jsign/releases/download/7.4/jsign_7.4_all.deb
         sudo dpkg -i jsign_7.4_all.deb
-       
-    - name: Setup KeyLocker Client Authentication Certificate
-      run: | 
-        echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > client_auth_cert.p12
 
     - name: Sign MW Agent Installer Package
       run: |


### PR DESCRIPTION
### **User description**
The Windows build recently started failing during the signing process.

After having a chat with Digicert Tech team, found that they have rolled out some changes related to how github actions should be using Digicert APIs
https://docs.digicert.com/en/digicert-keylocker/ci-cd-integrations-and-deployment-pipelines/plugins/github/binary-signing-using-github-actions.html

Tested the suggested changes on a different branch.
This is working well, so bumping to `master`


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced manual `jsign` installation with official DigiCert action.

- Updated certificate setup to use `${RUNNER_TEMP}` directory.

- Configured `code-signing-software-trust-action` for installer signing.

- Integrated `SM_HOST` and other secrets into signing step.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Build["Build MW Agent"] -- "exe created" --> Cert["Setup Client Cert"]
  Cert -- "cert ready" --> Sign["Sign with DigiCert Action"]
  Sign -- "signed exe" --> Upload["Upload Artifact"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>host-agent-windows.yaml</strong><dd><code>Migrate Windows signing process to native DigiCert action</code></dd></summary>
<hr>

.github/workflows/host-agent-windows.yaml

<ul><li>Removed the manual installation of the <code>jsign</code> tool and its associated <br>command-line execution.<br> <li> Integrated the <code>digicert/code-signing-software-trust-action@v1</code> to <br>handle the signing of the Windows installer.<br> <li> Updated the certificate setup process to store the decoded <code>.p12</code> file <br>in the <code>${RUNNER_TEMP}</code> directory and export its path as <br><code>SM_CLIENT_CERT_FILE</code>.<br> <li> Added configuration for <code>SM_HOST</code> and other required secrets within the <br>new signing action step.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/320/files#diff-48abfac383b72c3d7d3737d77b76487442cdf4e282c206de6a70fbf1f42adddc">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

