### PR TITLE
AGE-528: Add nginx receiver metadata to the metrics catalog

### DIFF
--- a/metadata/base/metrics.json
+++ b/metadata/base/metrics.json
@@ -231,6 +231,14 @@
         "collection_interval": "10s"
     },
     {
+        "type": "nginx",
+        "prefixes": ["nginx"],
+        "files": [
+            "https://raw.githubusercontent.com/middleware-labs/opentelemetry-collector-contrib/main/receiver/nginxreceiver/metadata.yaml"
+        ],
+        "collection_interval": "10s"
+    },
+    {
         "type": "sqlserver",
         "prefixes": ["sqlserver"],
         "files": [


### PR DESCRIPTION
### **User description**
## What

Adds the nginx entry to `metadata/base/metrics.json`, pointing at the `nginxreceiver` metadata file.

## Why

The nginx receiver was missing from the metrics catalog. Bifrost's `populate-metrics` command reads this file, follows each `files` URL, and upserts the resulting metric definitions into the `builder_setting` table. With no nginx entry, no `nginx.*` definitions were ever written.

The Data Collected tab in the nginx integration reads those rows back via `GET /default/builder/settings?resourceType=nginx&metricType=<n>`, so it rendered empty — no metrics and no attributes listed.

## What this adds

Parsing the referenced metadata yields 31 rows:

- **27 metrics** — connections (`accepted`/`current`/`handled`, `net.reading`/`waiting`/`writing`), `requests`, `load_timestamp`, server zone received/sent and 1xx–5xx responses, and upstream peer metrics
- **4 metric attributes** — `state`, `serverzone_name`, `upstream_block_name`, `upstream_peer_address`

`collection_interval` is `10s`, matching the other integration receivers in the file.

## Known gap (not addressed here)

The nginx `metadata.yaml` declares `attributes` and `metrics` but has no `resource_attributes` block, unlike apache/redis/mysql. The Resource Attributes table on that tab will therefore still be empty after this change. Fixing that means adding a `resource_attributes` section to the nginx receiver in the collector-contrib fork — a separate PR.

## Rollout

The URL bifrost reads is pinned to `refs/heads/master`, so this takes effect once merged. It is picked up on the next `cron-job-24-hours` run, or immediately via `app mwadmin populate-metrics`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Nginx receiver metadata to metrics catalog.

- Enable Nginx metric scraping for Bifrost.

- Set 10s collection interval for Nginx.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MC["metrics.json"] -- "Add nginx entry" --> NR["nginxreceiver metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics.json</strong><dd><code>Add Nginx receiver configuration to metrics catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

metadata/base/metrics.json

<ul><li>Added a new configuration block for the <code>nginx</code> receiver type.<br> <li> Linked the <code>nginxreceiver</code> metadata YAML from the OpenTelemetry <br>collector contrib repository.<br> <li> Defined the <code>nginx</code> prefix and set a 10-second <code>collection_interval</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/mw-agent/pull/321/files#diff-9b6ea861d14585d44ab91da0915c95cd134937aa84bec96189f3143a8ca1fba9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

